### PR TITLE
Updating winhttp

### DIFF
--- a/source/code/include/playfab/PlayFabError.h.ejs
+++ b/source/code/include/playfab/PlayFabError.h.ejs
@@ -29,6 +29,7 @@ namespace PlayFab
         std::string ErrorMessage;
         Json::Value ErrorDetails;
         Json::Value Data;
+        std::string RequestId;
         // Non-serialized fields
         std::string UrlPath;
         Json::Value Request;

--- a/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <atomic>
 
-#include <json/value.h>
+#include <json/json.h>
 #include <playfab/PlayFabIXHR2HttpRequest.h>
 
 namespace PlayFab

--- a/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIXHR2HttpPlugin.h
@@ -10,7 +10,7 @@
 #include <mutex>
 #include <atomic>
 
-#include <json/json.h>
+#include <json/value.h>
 #include <playfab/PlayFabIXHR2HttpRequest.h>
 
 namespace PlayFab

--- a/source/code/include/playfab/PlayFabIXHR2HttpRequest.h
+++ b/source/code/include/playfab/PlayFabIXHR2HttpRequest.h
@@ -62,6 +62,7 @@ namespace PlayFab
         const BOOL      WaitForFinish();
         const std::wstring& GetHeaders()  const { return m_headers; };
         const std::wstring& GetData()     const { return m_data; };
+        const std::wstring& GetResponseRequestId()  const { return m_responseRequestId; };
         HRESULT   GetHR()           const { return m_hr; };
         DWORD     GetHTTPStatus()   const { return m_httpStatus; };
 
@@ -76,6 +77,7 @@ namespace PlayFab
         DWORD        m_httpStatus;
         std::wstring m_headers;
         std::wstring m_data;
+        std::wstring m_responseRequestId;
     };
 
     // ----------------------------------------------------------------------------
@@ -149,6 +151,7 @@ namespace PlayFab
 
         const std::wstring& GetHeaders() { return m_pHttpCallback->GetHeaders(); }
         const std::wstring& GetData() { return m_pHttpCallback->GetData(); }
+        const std::wstring& GetResponseRequestId() { return m_pHttpCallback->GetResponseRequestId(); }
 
     private:
         HRESULT CreateRequest(const std::wstring& verb, const std::wstring& url);

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -30,7 +30,7 @@ namespace PlayFab
         virtual std::string GetUrl(CallRequestContainer& requestContainer) const;
         virtual void SetPredefinedHeaders(CallRequestContainer& requestContainer, HINTERNET hRequest);
         virtual bool GetBinaryPayload(CallRequestContainer& requestContainer, LPVOID& payload, DWORD& payloadSize) const;
-        virtual void ProcessResponse(CallRequestContainer& requestContainer, const int httpCode);
+        virtual void ProcessResponse(CallRequestContainer& requestContainer, const int httpCode, std::string&& requestId);
         void WorkerThread();
         void HandleCallback(std::unique_ptr<CallRequestContainer> requestContainer);
         void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -174,8 +174,11 @@ namespace PlayFab
 
         const HRESULT res = postEventRequest.GetResult();
         const DWORD status = postEventRequest.GetStatus();
-        auto response = postEventRequest.GetData();
+        const auto& response = postEventRequest.GetData();
+        const auto& responseRequestId = postEventRequest.GetResponseRequestId();
+
         reqContainer.responseString = std::string(response.begin(), response.end());
+        reqContainer.errorWrapper.RequestId = std::string(responseRequestId.begin(), responseRequestId.end());
 
         // 401 is a special case where the status does not bubble up and we have to parse it from the HRESULT
         if (status == 401)

--- a/source/code/source/playfab/PlayFabIXHR2HttpRequest.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpRequest.cpp
@@ -114,6 +114,17 @@ IFACEMETHODIMP HttpCallback::OnHeadersAvailable(IXMLHTTPRequest2 *pXHR, DWORD dw
         hr = S_OK;
     }
 
+    if (SUCCEEDED(hr))
+    {
+        wchar_t* responseRequestId;
+        hr = pXHR->GetResponseHeader(L"X-RequestId", &responseRequestId);
+        if (SUCCEEDED(hr))
+        {
+            m_responseRequestId = responseRequestId;
+            ::CoTaskMemFree(responseRequestId);
+        }
+    }
+
     // The header string that was passed in needs to be deleted here.
     if (headers != nullptr)
     {
@@ -424,7 +435,7 @@ HRESULT HttpRequest::Open(const std::wstring& verb, const std::wstring& url, con
     {
         // Create and open a new runtime class
         m_requestStream = Make<RequestStream>();
-        m_requestStream->Open(data.c_str(), static_cast<ULONG>(data.length()));
+        m_requestStream->Open(data.c_str(), static_cast<uint32_t>(data.length()));
 
         hr = m_pXHR->Send(m_requestStream.Get(),        // body message as an ISequentialStream*
             m_requestStream->Size());    // count of bytes in the stream.
@@ -516,7 +527,7 @@ HRESULT HttpRequest::Open(const std::wstring& verb, const std::wstring& url, con
     {
         // Create and open a new runtime class
         m_requestStream = Make<RequestStream>();
-        m_requestStream->Open(reinterpret_cast<const char*>(data), datalength);
+        m_requestStream->Open(reinterpret_cast<const char*>(data), static_cast<uint32_t>(datalength));
 
         hr = m_pXHR->Send(m_requestStream.Get(),        // body message as an ISequentialStream*
             m_requestStream->Size());    // count of bytes in the stream.


### PR DESCRIPTION
enabling the bility to set a request ID so responses can keep track of what request id this particular callback is for.