### PR TITLE
Toddbell/android fixes

### DIFF
--- a/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
@@ -47,7 +47,7 @@ namespace PlayFab
 
             bool Initialize(std::unique_ptr<CallRequestContainerBase>& requestContainer);
             
-            enum State:int
+            enum class State:int
             {
                 None = 0,
                 Pending = RequestTask::None,

--- a/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
@@ -49,7 +49,7 @@ namespace PlayFab
             
             enum class State:int
             {
-                None,
+                None = 0,
                 Pending = (int)RequestTask::State::None,
                 Requesting,
                 Finished

--- a/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabAndroidHttpPlugin.h
@@ -49,8 +49,8 @@ namespace PlayFab
             
             enum class State:int
             {
-                None = 0,
-                Pending = RequestTask::None,
+                None,
+                Pending = (int)RequestTask::State::None,
                 Requesting,
                 Finished
             };

--- a/source/code/include/playfab/PlayFabError.h.ejs
+++ b/source/code/include/playfab/PlayFabError.h.ejs
@@ -5,7 +5,7 @@
 
 namespace PlayFab
 {
-    enum PlayFabErrorCode
+    enum  class PlayFabErrorCode
     {
         PlayFabErrorHostnameNotFound = 1,
         PlayFabErrorConnectionTimeout,

--- a/source/code/include/playfab/PlayFabIOSHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIOSHttpPlugin.h
@@ -43,7 +43,7 @@ namespace PlayFab
 
             bool Initialize(std::unique_ptr<CallRequestContainerBase>& requestContainer);
             
-            enum State:int
+            enum class State:int
             {
                 None = 0,
                 Pending = RequestTask::None,

--- a/source/code/include/playfab/PlayFabIOSHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIOSHttpPlugin.h
@@ -45,7 +45,7 @@ namespace PlayFab
             
             enum class State:int
             {
-                None,
+                None = 0,
                 Pending = (int)RequestTask::State::None,
                 Requesting,
                 Finished

--- a/source/code/include/playfab/PlayFabIOSHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIOSHttpPlugin.h
@@ -45,8 +45,8 @@ namespace PlayFab
             
             enum class State:int
             {
-                None = 0,
-                Pending = RequestTask::None,
+                None,
+                Pending = (int)RequestTask::State::None,
                 Requesting,
                 Finished
             };

--- a/source/code/include/playfab/QoS/QoS.h
+++ b/source/code/include/playfab/QoS/QoS.h
@@ -25,7 +25,7 @@ namespace PlayFab
         constexpr int NUM_OF_PING_ITERATIONS = 3;
 
         // These are possible error code for QoSResult.errorCode
-        enum QoSErrorCode
+        enum class QoSErrorCode
         {
             Success = 0,
             NotLoggedIn = 1,

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -203,7 +203,7 @@ namespace PlayFab
     };
 
     PlayFabAndroidHttpPlugin::RequestTask::RequestTask() :
-        state(RequestTask::None),
+        state(RequestTask::State::None),
         impl(nullptr),
         requestContainer(nullptr)
     {
@@ -261,7 +261,7 @@ namespace PlayFab
         if(requestTask != nullptr)
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
-            requestTask->state = RequestTask::Pending;
+            requestTask->state = RequestTask::State::Pending;
             pendingRequests.push_back(std::move(requestTask));
             if(workerThread == nullptr)
             {
@@ -352,30 +352,30 @@ namespace PlayFab
                 state = this->requestingTask->state;
             } // UNLOCK httpRequestMutex
             switch (state) {
-                case RequestTask::Pending:
+                case RequestTask::State::Pending:
                 {
                     if (ExecuteRequest(*(this->requestingTask)))
                     {
-                        this->requestingTask->state = RequestTask::Requesting;
+                        this->requestingTask->state = RequestTask::State::Requesting;
                     }
                     else
                     {
                         SetResponseAsBadRequest(*(this->requestingTask));
-                        this->requestingTask->state = RequestTask::Finished;
+                        this->requestingTask->state = RequestTask::State::Finished;
                     }
                     break;
                 }
-                case RequestTask::Requesting:
+                case RequestTask::State::Requesting:
                 {
                     if (CheckResponse(*(this->requestingTask)) == false)
                     {
                         SetResponseAsBadRequest(*(this->requestingTask));
-                        this->requestingTask->state = RequestTask::Finished;
+                        this->requestingTask->state = RequestTask::State::Finished;
                     }
                     std::this_thread::yield();
                     break;
                 }
-                case RequestTask::Finished:
+                case RequestTask::State::Finished:
                 {
                     if (PlayFabSettings::threadedCallbacks)
                     {
@@ -583,7 +583,7 @@ namespace PlayFab
 
             { // LOCK httpRequestMutex
                 std::unique_lock<std::mutex> lock(httpRequestMutex);
-                requestTask.state = RequestTask::Finished;
+                requestTask.state = RequestTask::State::Finished;
             } // UNLOCK httpRequestMutex
         }
 

--- a/source/code/source/playfab/PlayFabError.cpp
+++ b/source/code/source/playfab/PlayFabError.cpp
@@ -25,7 +25,7 @@ namespace PlayFab
         // This is not expected to be used, but implemented for completeness
         Json::Value output;
         output["code"] = Json::Value(HttpCode);
-        output["errorCode"] = Json::Value(ErrorCode);
+        output["errorCode"] = Json::Value(static_cast<int>(ErrorCode));
         output["status"] = Json::Value(HttpStatus);
         output["error"] = Json::Value(ErrorName);
         output["errorMessage"] = Json::Value(ErrorMessage);

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -33,7 +33,7 @@ namespace PlayFab
     };
 
     PlayFabIOSHttpPlugin::RequestTask::RequestTask() :
-        state(RequestTask::None),
+        state(RequestTask::State::None),
         impl(nullptr),
         requestContainer(nullptr)
     {
@@ -108,7 +108,7 @@ namespace PlayFab
         if(requestTask != nullptr)
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
-            requestTask->state = RequestTask::Pending;
+            requestTask->state = RequestTask::State::Pending;
             pendingRequests.push_back(std::move(requestTask));
             if(workerThread == nullptr)
             {
@@ -176,18 +176,18 @@ namespace PlayFab
             } // UNLOCK httpRequestMutex
             switch (state)
             {
-                case RequestTask::Pending:
+                case RequestTask::State::Pending:
                 {
                     ExecuteRequest(*(this->requestingTask));
-                    this->requestingTask->state = RequestTask::Requesting;
+                    this->requestingTask->state = RequestTask::State::Requesting;
                     break;
                 }
-                case RequestTask::Requesting:
+                case RequestTask::State::Requesting:
                 {
                     std::this_thread::yield();
                     break;
                 }
-                case RequestTask::Finished:
+                case RequestTask::State::Finished:
                 {
                     if (PlayFabSettings::threadedCallbacks)
                     {
@@ -262,7 +262,7 @@ namespace PlayFab
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex
                                                                            lock->lock();
-                                                                           request->state = RequestTask::Finished;
+                                                                           request->state = RequestTask::State::Finished;
                                                                            lock->unlock();
                                                                        } // UNLOCK httpRequestMutex
                                                                    }];

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -93,7 +93,7 @@ namespace PlayFab
 
         QoSResult PlayFabQoSApi::GetQoSResult(unsigned int numThreads, unsigned int timeoutMs)
         {
-            QoSResult result(move(GetResult(numThreads, timeoutMs)));
+            QoSResult result(GetResult(numThreads, timeoutMs));
 
             if (result.errorCode != static_cast<int>(QoSErrorCode::Success))
             {
@@ -135,7 +135,7 @@ namespace PlayFab
 
             // get a list of region pings that need to be done
             result.regionResults.reserve(serverCount);
-            vector<std::string> pings = move(GetPingList(static_cast<unsigned int>(serverCount)));
+            vector<std::string> pings = GetPingList(static_cast<unsigned int>(serverCount));
 
             // initialize accumulated results with empty (zeroed) ping results
             unordered_map<std::string, PingResult> accumulatedPingResults;
@@ -166,7 +166,7 @@ namespace PlayFab
             {
                 // Calculate the latency
                 int latency = (it->second.pingCount == 0) ? INT32_MAX : it->second.latencyMs / it->second.pingCount;
-                result.regionResults.push_back(move(RegionResult(it->first, latency, it->second.errorCode)));
+                result.regionResults.push_back(RegionResult(it->first, latency, it->second.errorCode));
             }
 
             std::sort(result.regionResults.begin(), result.regionResults.end(), [](const RegionResult& first, const RegionResult& second) -> bool {return first.latencyMs < second.latencyMs; });
@@ -308,7 +308,7 @@ namespace PlayFab
         {
             for (int i = 0; i < asyncPingResults.size(); ++i)
             {
-                asyncPingResults[i] = move(future<PingResult>()); // create a fake future
+                asyncPingResults[i] = future<PingResult>(); // create a fake future
             }
         }
 

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -95,7 +95,7 @@ namespace PlayFab
         {
             QoSResult result(move(GetResult(numThreads, timeoutMs)));
 
-            if (result.errorCode != QoSErrorCode::Success)
+            if (result.errorCode != static_cast<int>(QoSErrorCode::Success))
             {
                 return result;
             }
@@ -111,7 +111,7 @@ namespace PlayFab
             if (!PlayFabClientAPI::IsClientLoggedIn())
             {
                 LOG_QOS("Client is not logged in" << endl);
-                result.errorCode = QoSErrorCode::NotLoggedIn;
+                result.errorCode = static_cast<int>(QoSErrorCode::NotLoggedIn);
                 return result;
             }
 
@@ -129,7 +129,7 @@ namespace PlayFab
             size_t serverCount = regionMap.size(); // call thunderhead to get a list of all the data centers
             if (serverCount <= 0)
             {
-                result.errorCode = QoSErrorCode::FailedToRetrieveServerList;
+                result.errorCode = static_cast<int>(QoSErrorCode::FailedToRetrieveServerList);
                 return result;
             }
 

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -151,7 +151,7 @@ namespace PlayFab
                 return -1;
             }
 
-            return sendto(s, message, static_cast<int>(strlen(message)), 0, (struct sockaddr *) &siOther, slen);
+            return static_cast<int>(sendto(s, message, static_cast<int>(strlen(message)), 0, (struct sockaddr *) &siOther, slen));
         }
 
         int XPlatSocket::ReceiveReply(char* buf, const int& buflen)
@@ -178,7 +178,7 @@ namespace PlayFab
                 {
                     return platformSpecificError();
                 }
-                return recvResult;
+                return static_cast<int>(recvResult);
             }
             else if (selectResult < 0)
             {

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -5,10 +5,10 @@
 #include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabSettings.h>
 #include <playfab/PlayFabAuthenticationDataModels.h>
-#include <playfab/PlayFabAuthenticationAPI.h>
+#include <playfab/PlayFabAuthenticationApi.h>
 #include <playfab/PlayFabClientDataModels.h>
 #include <playfab/PlayFabDataDataModels.h>
-#include <playfab/PlayFabDataAPI.h>
+#include <playfab/PlayFabDataApi.h>
 #include <playfab/PlayFabPlatformMacros.h>
 #include "PlayFabApiTest.h"
 #include "TestContext.h"

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -185,7 +185,7 @@ namespace PlayFabUnit
 
         std::shared_ptr<PlayFabEventAPI*> api = SetupEventTest();
 
-        (*api)->EmitEvent(std::move(MakeEvent(0, PlayFabEventType::Default)),
+        (*api)->EmitEvent(MakeEvent(0, PlayFabEventType::Default),
             [&testContext]
             (std::shared_ptr<const IPlayFabEvent>, std::shared_ptr<const IPlayFabEmitEventResponse>)
             { if(testContext.activeState != TestActiveState::COMPLETE){ testContext.Pass("Lambda Function Callback Succeeded.");}});
@@ -197,7 +197,7 @@ namespace PlayFabUnit
 
         std::shared_ptr<PlayFabEventAPI*> api = SetupEventTest();
 
-        (*api)->EmitEvent(std::move(MakeEvent(0, PlayFabEventType::Default)),
+        (*api)->EmitEvent(MakeEvent(0, PlayFabEventType::Default),
         std::bind(&PlayFabEventTest::NonStaticEmitEventCallback, this, std::placeholders::_1, std::placeholders::_2));
     }
 

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -106,7 +106,7 @@ namespace PlayFabUnit
                     "in the batch #" + std::to_string(pfResponse->batchNumber) + " "
                     "of " + std::to_string(pfResponse->batch->size()) + " events. "
                     "HTTP code: " + std::to_string(pfResponse->playFabError->HttpCode) +
-                    ", app error code: " + std::to_string(pfResponse->playFabError->ErrorCode) + "\n";
+                    ", app error code: " + std::to_string(static_cast<int>(pfResponse->playFabError->ErrorCode)) + "\n";
 
                 // Keep track of the highest batch number.
                 eventBatchMax = (pfResponse->batchNumber > eventBatchMax) ? pfResponse->batchNumber : eventBatchMax;
@@ -119,7 +119,7 @@ namespace PlayFabUnit
                     "in the batch #" + std::to_string(pfResponse->batchNumber) + " "
                     "of " + std::to_string(pfResponse->batch->size()) + " events. "
                     "HTTP code: " + std::to_string(pfResponse->playFabError->HttpCode) +
-                    ", app error code: " + std::to_string(pfResponse->playFabError->ErrorCode) +
+                    ", app error code: " + std::to_string(static_cast<int>(pfResponse->playFabError->ErrorCode)) +
                     ", HTTP status: " + pfResponse->playFabError->HttpStatus +
                     ", Message: " + pfResponse->playFabError->ErrorMessage +
                     "\n";

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -83,7 +83,7 @@ namespace PlayFabUnit
             case TestFinishState::SKIPPED: internalReport.skipped += 1; break;
             case TestFinishState::PENDING:
                 break;
-            case TestFinishState::TIMEOUT: 
+            case TestFinishState::TIMEDOUT: 
                 break;
             default:
                 break;

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -81,6 +81,12 @@ namespace PlayFabUnit
             case TestFinishState::PASSED: internalReport.passed += 1; break;
             case TestFinishState::FAILED: internalReport.failures += 1; break;
             case TestFinishState::SKIPPED: internalReport.skipped += 1; break;
+            case TestFinishState::PENDING:
+                break;
+            case TestFinishState::TIMEOUT: 
+                break;
+            default:
+                break;
         }
 
         // Update overall runtime.

--- a/templates/PlayFab_DataModels.h.ejs
+++ b/templates/PlayFab_DataModels.h.ejs
@@ -20,14 +20,14 @@ for (var enumIdx = 0; enumIdx < enumtypes.length; enumIdx++) { var enumtype = en
         inline void ToJsonEnum(const <%- enumtype.name %> input, Json::Value& output)
         {
 <% for(var i=0; i<enumtype.enumvalues.length; i++) { var enumval = enumtype.enumvalues[i]
-%>            if (input == <%- enumtype.name %><%- enumval.name %>) output = Json::Value("<%- enumval.name %>");
+%>            if (input == <%- enumtype.name %>::<%- enumtype.name %><%- enumval.name %>) output = Json::Value("<%- enumval.name %>");
 <% } %>        }
         inline void FromJsonEnum(const Json::Value& input, <%- enumtype.name %>& output)
         {
             if (!input.isString()) return;
             const std::string& inputStr = input.asString();
 <% for(var i=0; i<enumtype.enumvalues.length; i++) { var enumval = enumtype.enumvalues[i]
-%>            if (inputStr == "<%- enumval.name %>") output = <%- enumtype.name %><%- enumval.name %>;
+%>            if (inputStr == "<%- enumval.name %>") output = <%- enumtype.name %>::<%- enumtype.name %><%- enumval.name %>;
 <% } %>        }
 <% } %>
         // <%- api.name %> Classes<%

--- a/templates/PlayFab_DataModels.h.ejs
+++ b/templates/PlayFab_DataModels.h.ejs
@@ -11,7 +11,7 @@ namespace PlayFab
     {
         // <%- api.name %> Enums<%
 for (var enumIdx = 0; enumIdx < enumtypes.length; enumIdx++) { var enumtype = enumtypes[enumIdx]; %>
-        enum <%- enumtype.name %>
+        enum class <%- enumtype.name %>
         {
             <% for(var i=0; i<enumtype.enumvalues.length-1; i++) { var enumval = enumtype.enumvalues[i] %><%- enumtype.name %><%- enumval.name %>,
             <% } %><%- enumtype.name %><%- enumtype.enumvalues[enumtype.enumvalues.length-1].name %>


### PR DESCRIPTION
Fixing some android and iOS issues. There were reports of enum's that weren't enum class's which would throw warnings. There should now be only expected warnings about testTitleData.json files existing or not.