### PR TITLE
Removes most of the warnings in XPlat core and XPlat consoles

### DIFF
--- a/source/code/include/playfab/PlayFabApiSettings.h
+++ b/source/code/include/playfab/PlayFabApiSettings.h
@@ -11,9 +11,6 @@ namespace PlayFab
     class PlayFabApiSettings
     {
     public:
-        std::string verticalName; // The name of a PlayFab service vertical
-        std::string baseServiceHost; // The base for a PlayFab service host
-        std::string titleId; // You must set this value for PlayFabSdk to work properly (found in the Game Manager for your title, at the PlayFab Website)
 #ifndef DISABLE_PLAYFABCLIENT_API
         std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant (defined in PlayFabSettings)
         std::string advertisingIdValue; // Set this to corresponding device value
@@ -22,6 +19,10 @@ namespace PlayFab
         // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
         bool disableAdvertising;
 #endif
+
+        std::string verticalName; // The name of a PlayFab service vertical
+        std::string baseServiceHost; // The base for a PlayFab service host
+        std::string titleId; // You must set this value for PlayFabSdk to work properly (found in the Game Manager for your title, at the PlayFab Website)
 
         PlayFabApiSettings();
         std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams) const;

--- a/source/code/include/playfab/PlayFabPluginManager.h
+++ b/source/code/include/playfab/PlayFabPluginManager.h
@@ -34,7 +34,7 @@ namespace PlayFab
         /// starts the process of making a post request.
         /// A user is expected to supply their own CallRequestContainerBase
         /// </summary>
-        virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase>) = 0;
+        virtual void MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer) = 0;
 
         /// <summary>
         /// updates the process of making post requests.

--- a/source/code/include/playfab/PlayFabSettings.h
+++ b/source/code/include/playfab/PlayFabSettings.h
@@ -47,7 +47,7 @@ namespace PlayFab
 
         static std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams);
 #endif
-        static bool ValidateSettings(const std::string& apiAuth, const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container);
+        static bool ValidateSettings(const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container);
     private:
         PlayFabSettings(); // Private constructor, static class should never have an instance
         PlayFabSettings(const PlayFabSettings& other); // Private copy-constructor, static class should never have an instance

--- a/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -14,9 +14,9 @@ namespace PlayFab
         url(url),
         headers(headers),
         requestBody(requestBody),
+        apiSettings(settings),
         callback(callback),
-        customData(customData),
-        apiSettings(settings)
+        customData(customData)
     {
     }
 

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -79,7 +79,7 @@ namespace PlayFab
         return fullUrl;
     }
 
-    bool PlayFabSettings::ValidateSettings(const std::string& apiAuth, const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container)
+    bool PlayFabSettings::ValidateSettings(const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container)
     {
         bool valid = true;
         if (PlayFabSettings::titleId.empty())

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -2,8 +2,6 @@
 
 #include <playfab/PlayFabSettings.h>
 
-#pragma warning (disable: 4100) // formal parameters are part of a public interface
-
 namespace PlayFab
 {
     const std::string PlayFabSettings::sdkVersion = "<%- sdkVersion %>";
@@ -105,5 +103,3 @@ namespace PlayFab
         return false;
     }
 }
-
-#pragma warning (default: 4100) // formal parameters are part of a public interface

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 #include <windows.h>
 
-#pragma warning (disable: 4100) // formal parameters are part of a public interface
 #pragma warning (disable: 4245) // Some DWORD arguments of WinHTTP API can accept -1, according to documentation
 
 namespace PlayFab

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -1,5 +1,7 @@
 #include <stdafx.h>
 
+#if defined(PLAYFAB_PLATFORM_WINDOWS)
+
 #include <playfab/PlayFabWinHttpPlugin.h>
 #include <playfab/PlayFabSettings.h>
 #include <stdexcept>
@@ -191,7 +193,7 @@ namespace PlayFab
                         auto headers = reqContainer.GetHeaders();
                         if (headers.size() > 0)
                         {
-                            for (auto const &obj : headers)
+                            for (auto const& obj : headers)
                             {
                                 if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
                                 {
@@ -356,6 +358,7 @@ namespace PlayFab
 
     void PlayFabWinHttpPlugin::SetPredefinedHeaders(const CallRequestContainer& requestContainer, HINTERNET hRequest)
     {
+        UNREFERENCED_PARAMETER(requestContainer);
         WinHttpAddRequestHeaders(hRequest, L"Accept: application/json", -1, 0);
         WinHttpAddRequestHeaders(hRequest, L"Content-Type: application/json; charset=utf-8", -1, 0);
         WinHttpAddRequestHeaders(hRequest, (L"X-PlayFabSDK: " + std::wstring(PlayFabSettings::versionString.begin(), PlayFabSettings::versionString.end())).c_str(), -1, 0);
@@ -364,6 +367,9 @@ namespace PlayFab
 
     bool PlayFabWinHttpPlugin::GetBinaryPayload(CallRequestContainer& reqContainer, LPVOID& payload, DWORD& payloadSize) const
     {
+        UNREFERENCED_PARAMETER(reqContainer);
+        UNREFERENCED_PARAMETER(payload);
+        UNREFERENCED_PARAMETER(payloadSize);
         return false;
     }
 
@@ -448,3 +454,5 @@ namespace PlayFab
         }
     }
 }
+
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS)

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -66,9 +66,7 @@ namespace PlayFab
         {
             IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
             const auto requestJson = request.ToJson();
-
-            Json::FastWriter writer;
-            std::string jsonAsString = writer.write(requestJson);
+            std::string jsonAsString = requestJson.toStyledString();
 
             std::unordered_map<std::string, std::string> headers;
             headers.emplace("X-EntityToken", request.authenticationContext == nullptr ? PlayFabSettings::entityToken : request.authenticationContext->entityToken);

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -59,8 +59,8 @@ namespace PlayFab
 
         void WriteTelemetryEvents(
             WriteEventsRequest& request,
-            const ProcessApiCallback<WriteEventsResponse>& callback,
-            const ErrorCallback& errorCallback = nullptr,
+            const ProcessApiCallback<WriteEventsResponse> callback,
+            const ErrorCallback errorCallback = nullptr,
             void* customData = nullptr
         )
         {

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -1,7 +1,5 @@
 #include <stdafx.h>
 
-#pragma warning (disable: 4996)         // Suppress the warning thrown for _WINSOCK_DEPRECATED_NO_WARNINGS by the getHostByName api
-
 #include <playfab/QoS/XPlatSocket.h>
 #include <playfab/QoS/QoS.h>
 

--- a/templates/PlayFab_API.h.ejs
+++ b/templates/PlayFab_API.h.ejs
@@ -22,7 +22,7 @@ namespace PlayFab
 <% } %>
         // ------------ Generated API calls
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        static void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>> callback, ErrorCallback errorCallback = nullptr, void* customData = nullptr);
+%>        static void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>>& callback, const ErrorCallback& errorCallback = nullptr, void* customData = nullptr);
 <% } %>
     private:
         PlayFab<%- api.name %>API(); // Private constructor, static class should never have an instance

--- a/templates/PlayFab_API.h.ejs
+++ b/templates/PlayFab_API.h.ejs
@@ -22,7 +22,7 @@ namespace PlayFab
 <% } %>
         // ------------ Generated API calls
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        static void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>>& callback, const ErrorCallback& errorCallback = nullptr, void* customData = nullptr);
+%>        static void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>> callback, const ErrorCallback errorCallback = nullptr, void* customData = nullptr);
 <% } %>
     private:
         PlayFab<%- api.name %>API(); // Private constructor, static class should never have an instance

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -54,7 +54,7 @@ namespace PlayFab
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
-        if (PlayFabSettings::ValidateSettings("<%- apiCall.auth %>", request.authenticationContext, nullptr, *reqContainer))
+        if (PlayFabSettings::ValidateSettings(request.authenticationContext, nullptr, *reqContainer))
         {
             http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
         }

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -8,7 +8,9 @@
 #include <playfab/PlayFabError.h>
 #include <memory>
 
+#if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (disable: 4100) // formal parameters are part of a public interface
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS)
 
 namespace PlayFab
 {
@@ -29,17 +31,15 @@ namespace PlayFab
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx]; %>
     void PlayFab<%- api.name %>API::<%- apiCall.name %>(
         <%- apiCall.request %>& request,
-        ProcessApiCallback<<%- apiCall.result %>> callback,
-        ErrorCallback errorCallback,
+        const ProcessApiCallback<<%- apiCall.result %>>& callback,
+        const ErrorCallback& errorCallback,
         void* customData
     )
     {
 <%- getRequestActions("        ", apiCall, false) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const auto requestJson = request.ToJson();
-
-        Json::FastWriter writer;
-        std::string jsonAsString = writer.write(requestJson);
+        std::string jsonAsString = requestJson.toStyledString();
 
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall, false) %>);
@@ -119,4 +119,6 @@ namespace PlayFab
 
 #endif
 
+#if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (default: 4100) // formal parameters are part of a public interface
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS)

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -31,8 +31,8 @@ namespace PlayFab
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx]; %>
     void PlayFab<%- api.name %>API::<%- apiCall.name %>(
         <%- apiCall.request %>& request,
-        const ProcessApiCallback<<%- apiCall.result %>>& callback,
-        const ErrorCallback& errorCallback,
+        const ProcessApiCallback<<%- apiCall.result %>> callback,
+        const ErrorCallback errorCallback,
         void* customData
     )
     {

--- a/templates/PlayFab_InstanceAPI.h.ejs
+++ b/templates/PlayFab_InstanceAPI.h.ejs
@@ -42,7 +42,7 @@ namespace PlayFab
 <% } %>
         // ------------ Generated API calls
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>> callback, ErrorCallback errorCallback = nullptr, void* customData = nullptr);
+%>        void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>>& callback, const ErrorCallback& errorCallback = nullptr, void* customData = nullptr);
 <% } %>
         // ------------ Generated result handlers
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];

--- a/templates/PlayFab_InstanceAPI.h.ejs
+++ b/templates/PlayFab_InstanceAPI.h.ejs
@@ -42,7 +42,7 @@ namespace PlayFab
 <% } %>
         // ------------ Generated API calls
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];
-%>        void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>>& callback, const ErrorCallback& errorCallback = nullptr, void* customData = nullptr);
+%>        void <%- apiCall.name %>(<%- api.name %>Models::<%- apiCall.request %>& request, const ProcessApiCallback<<%- api.name %>Models::<%- apiCall.result %>> callback, const ErrorCallback errorCallback = nullptr, void* customData = nullptr);
 <% } %>
         // ------------ Generated result handlers
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx];

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -88,8 +88,8 @@ namespace PlayFab
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx]; %>
     void PlayFab<%- api.name %>InstanceAPI::<%- apiCall.name %>(
         <%- apiCall.request %>& request,
-        ProcessApiCallback<<%- apiCall.result %>> callback,
-        ErrorCallback errorCallback,
+        const ProcessApiCallback<<%- apiCall.result %>>& callback,
+        const ErrorCallback& errorCallback,
         void* customData
     )
     {
@@ -113,7 +113,7 @@ namespace PlayFab
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
-        if (PlayFabSettings::ValidateSettings("<%- apiCall.auth %>", authenticationContext, this->settings, *reqContainer))
+        if (PlayFabSettings::ValidateSettings(authenticationContext, this->settings, *reqContainer))
         {
             http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
         }

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -8,7 +8,9 @@
 #include <playfab/PlayFabError.h>
 #include <memory>
 
+#if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (disable: 4100) // formal parameters are part of a public interface
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS)
 
 namespace PlayFab
 {
@@ -94,9 +96,7 @@ namespace PlayFab
 <%- getRequestActions("        ", apiCall, true) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const auto requestJson = request.ToJson();
-
-        Json::FastWriter writer;
-        std::string jsonAsString = writer.write(requestJson);
+        std::string jsonAsString = requestJson.toStyledString();
 
         auto authenticationContext = request.authenticationContext == nullptr ? this->GetOrCreateAuthenticationContext() : request.authenticationContext;
         std::unordered_map<std::string, std::string> headers;
@@ -196,4 +196,6 @@ namespace PlayFab
 
 #endif
 
+#if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (default: 4100) // formal parameters are part of a public interface
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS)

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -88,8 +88,8 @@ namespace PlayFab
 <% for (var callIdx = 0; callIdx < api.calls.length; callIdx++) { var apiCall = api.calls[callIdx]; %>
     void PlayFab<%- api.name %>InstanceAPI::<%- apiCall.name %>(
         <%- apiCall.request %>& request,
-        const ProcessApiCallback<<%- apiCall.result %>>& callback,
-        const ErrorCallback& errorCallback,
+        const ProcessApiCallback<<%- apiCall.result %>> callback,
+        const ErrorCallback errorCallback,
         void* customData
     )
     {


### PR DESCRIPTION
Out of order initialization in some constructors
FastWriter is deprecated, and easily replaced with toStyledString
4100 warnings only apply to Windows
Removing other pragma disables that aren't relevant anymore
And one bit of missed const correctness