### PR TITLE
Toddbell/auto fix

### DIFF
--- a/make.js
+++ b/make.js
@@ -9,6 +9,8 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
 
     var extraDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;";
 
+    sdkGlobals.sdkVersion = "3.19.191001";
+
     var locals = {
         apis: apis,
         buildIdentifier: sdkGlobals.buildIdentifier,
@@ -282,7 +284,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + "    #endif\n"
             + tabbing + "}\n"
             + tabbing + "else {\n"
-            + (isInstanceApi ? tabbing + "    auto authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
+            + (isInstanceApi ? tabbing + "    std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
             + tabbing + "    if (" + authContext + "entityToken.length() > 0) {\n"
             + tabbing + "        authKey = \"X-EntityToken\"; authValue = " + authContext + "entityToken;\n"
             + tabbing + "    }\n"
@@ -319,7 +321,7 @@ function getResultActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "{\n"
             + tabbing + "    outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n"
             + tabbing + "    outResult.authenticationContext->clientSessionTicket = outResult.SessionTicket;\n"
-            + (isInstanceApi ? tabbing + "    auto authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
+            + (isInstanceApi ? tabbing + "    std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
             + tabbing + "    " + authContext + "clientSessionTicket = outResult.SessionTicket;\n"
             + tabbing + "    if (outResult.EntityToken.notNull()) {\n"
             + tabbing + "        outResult.authenticationContext->entityToken = outResult.EntityToken->EntityToken;\n"

--- a/make.js
+++ b/make.js
@@ -9,8 +9,6 @@ exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
 
     var extraDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;";
 
-    sdkGlobals.sdkVersion = "3.19.191001";
-
     var locals = {
         apis: apis,
         buildIdentifier: sdkGlobals.buildIdentifier,

--- a/source/build/Linux/TestAppLinux.cpp
+++ b/source/build/Linux/TestAppLinux.cpp
@@ -30,9 +30,9 @@ namespace PlayFabUnit
             return false;
         }
 
-        auto begin = titleDataFile.tellg();
+        std::streampos begin = titleDataFile.tellg();
         titleDataFile.seekg(0, std::ios::end);
-        auto end = titleDataFile.tellg();
+        std::streampos end = titleDataFile.tellg();
         testDataJsonLen = static_cast<int>(end - begin);
         testDataJson = std::make_shared<char*>(new char[testDataJsonLen + 1]);
 

--- a/source/build/Windows/TestAppWin32.cpp
+++ b/source/build/Windows/TestAppWin32.cpp
@@ -37,9 +37,9 @@ namespace PlayFabUnit
             return false;
         }
 
-        auto begin = titleDataFile.tellg();
+        std::streampos begin = titleDataFile.tellg();
         titleDataFile.seekg(0, std::ios::end);
-        auto end = titleDataFile.tellg();
+        std::streampos end = titleDataFile.tellg();
         testDataJsonLen = static_cast<int>(end - begin);
         testDataJson = std::make_shared<char*>(new char[testDataJsonLen + 1]);
 

--- a/source/build/Xbox/TestXboxApp/MainXBO.cpp
+++ b/source/build/Xbox/TestXboxApp/MainXBO.cpp
@@ -62,7 +62,7 @@ ref class ViewProvider sealed : public IFrameworkView
 
         void OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args)
         {
-            auto deferral = args->SuspendingOperation->GetDeferral();
+            SuspendingDeferral deferral = args->SuspendingOperation->GetDeferral();
 
             create_task([this, deferral]()
             {

--- a/source/build/Xbox/TestXboxApp/TestAppXBO.cpp
+++ b/source/build/Xbox/TestXboxApp/TestAppXBO.cpp
@@ -22,9 +22,9 @@ namespace PlayFabUnit
             return false;
         }
 
-        auto begin = titleDataFile.tellg();
+        std::streampos begin = titleDataFile.tellg();
         titleDataFile.seekg(0, std::ios::end);
-        auto end = titleDataFile.tellg();
+        std::streampos end = titleDataFile.tellg();
         testDataJsonLen = static_cast<int>(end - begin);
         testDataJson = std::make_shared<char*>(new char[testDataJsonLen + 1]);
 

--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -11,9 +11,9 @@ namespace PlayFab
     class CallRequestContainer : public CallRequestContainerBase
     {
     public:
-        CallRequestContainer(std::string url,
+        CallRequestContainer(const std::string& url,
             const std::unordered_map<std::string, std::string>& headers,
-            std::string requestBody,
+            const std::string& requestBody,
             CallRequestContainerCallback callback,
             void* customData = nullptr,
             std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -431,7 +431,7 @@ namespace PlayFab
 
         // Call SetUrl
         {
-            const std::string& requestUrl = GetUrl(requestTask);
+            const std::string requestUrl = GetUrl(requestTask);
 
             jmethodID methodId = jniEnv->GetMethodID(GetHelper().GetHttpRequestClass(), "setUrl", "(Ljava/lang/String;)Z");
             if (methodId == nullptr)
@@ -456,7 +456,8 @@ namespace PlayFab
         SetPredefinedHeaders(requestTask);
 
         // Call SetHeader
-        const auto& headers = requestContainer.GetRequestHeaders();
+        const std::unordered_map<std::string, std::string> headers = requestContainer.GetRequestHeaders();
+        
         if (!headers.empty())
         {
             for (auto const &obj : headers)

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -431,7 +431,7 @@ namespace PlayFab
 
         // Call SetUrl
         {
-            auto requestUrl = GetUrl(requestTask);
+            const std::string& requestUrl = GetUrl(requestTask);
 
             jmethodID methodId = jniEnv->GetMethodID(GetHelper().GetHttpRequestClass(), "setUrl", "(Ljava/lang/String;)Z");
             if (methodId == nullptr)
@@ -456,7 +456,7 @@ namespace PlayFab
         SetPredefinedHeaders(requestTask);
 
         // Call SetHeader
-        auto headers = requestContainer.GetRequestHeaders();
+        const auto& headers = requestContainer.GetRequestHeaders();
         if (!headers.empty())
         {
             for (auto const &obj : headers)
@@ -470,7 +470,7 @@ namespace PlayFab
 
         // Call SetBody
         {
-            auto requestUrl = GetUrl(requestTask);
+            const std::string& requestUrl = GetUrl(requestTask);
 
             jmethodID methodId = jniEnv->GetMethodID(GetHelper().GetHttpRequestClass(), "setBody", "([B)V");
             if (methodId == nullptr)
@@ -689,7 +689,7 @@ namespace PlayFab
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
 
-        auto callback = requestContainer.GetCallback();
+        const auto& callback = requestContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(requestContainer.responseJson.get("code", Json::Value::null).asInt(),

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -561,7 +561,7 @@ namespace PlayFab
                 methodId = jniEnv->GetMethodID(GetHelper().GetHttpRequestClass(), "getResponseHttpBody", "()[B");
                 if (methodId)
                 {
-                    auto responseBody = (jbyteArray)jniEnv->CallObjectMethod(httpRequestObject, methodId);
+                    jbyteArray responseBody = (jbyteArray)jniEnv->CallObjectMethod(httpRequestObject, methodId);
 
                     if (responseBody != nullptr)
                     {

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -471,7 +471,7 @@ namespace PlayFab
 
         // Call SetBody
         {
-            const std::string& requestUrl = GetUrl(requestTask);
+            const std::string requestUrl = GetUrl(requestTask);
 
             jmethodID methodId = jniEnv->GetMethodID(GetHelper().GetHttpRequestClass(), "setBody", "([B)V");
             if (methodId == nullptr)
@@ -690,7 +690,7 @@ namespace PlayFab
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
 
-        const auto& callback = requestContainer.GetCallback();
+        CallRequestContainerCallback callback = requestContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(requestContainer.responseJson.get("code", Json::Value::null).asInt(),

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -24,14 +24,12 @@ namespace PlayFab
         Json::Value request;
         std::string errs;
         Json::CharReaderBuilder builder;
-        Json::CharReader* reader = builder.newCharReader();
+        std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
 
         const char* reqBod = requestBody.c_str();
         size_t reqBodLength = requestBody.length();
 
         bool parsingSuccessful = reader->parse(reqBod, reqBod + reqBodLength, &request, &errs);
-
-        delete reader;
 
         if (parsingSuccessful)
         {

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -5,9 +5,9 @@
 
 namespace PlayFab
 {
-    CallRequestContainer::CallRequestContainer(std::string url,
+    CallRequestContainer::CallRequestContainer(const std::string& url,
         const std::unordered_map<std::string, std::string>& headers,
-        std::string requestBody,
+        const std::string& requestBody,
         CallRequestContainerCallback callback,
         void* customData,
         std::shared_ptr<PlayFabApiSettings> settings) :
@@ -22,8 +22,15 @@ namespace PlayFab
         errorWrapper.UrlPath = url;
 
         Json::Value request;
-        Json::Reader reader;
-        bool parsingSuccessful = reader.parse(requestBody, request);
+        std::string errs;
+        Json::CharReaderBuilder builder;
+        Json::CharReader* reader = builder.newCharReader();
+
+        const char* reqBod = requestBody.c_str();
+        size_t reqBodLength = requestBody.length();
+
+        bool parsingSuccessful = reader->parse(reqBod, reqBod + reqBodLength, &request, &errs);
+
 
         if (parsingSuccessful)
         {

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -31,6 +31,7 @@ namespace PlayFab
 
         bool parsingSuccessful = reader->parse(reqBod, reqBod + reqBodLength, &request, &errs);
 
+        delete reader;
 
         if (parsingSuccessful)
         {

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -128,7 +128,7 @@ namespace PlayFab
         curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
         curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
 
-        auto headers = reqContainer.GetRequestHeaders();
+        const auto& headers = reqContainer.GetRequestHeaders();
 
         if (headers.size() > 0)
         {
@@ -157,7 +157,7 @@ namespace PlayFab
 
         // Send
         curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYPEER, true);
-        const auto res = curl_easy_perform(curlHandle);
+        const auto& res = curl_easy_perform(curlHandle);
         long curlHttpResponseCode = 0;
         curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, &curlHttpResponseCode);
 
@@ -209,7 +209,7 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        auto callback = reqContainer.GetCallback();
+        const auto& callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -209,7 +209,7 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        const auto& callback = reqContainer.GetCallback();
+        CallRequestContainerCallback callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -128,7 +128,7 @@ namespace PlayFab
         curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
         curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
 
-        const auto& headers = reqContainer.GetRequestHeaders();
+        const std::unordered_map<std::string, std::string> headers = reqContainer.GetRequestHeaders();
 
         if (headers.size() > 0)
         {
@@ -157,7 +157,7 @@ namespace PlayFab
 
         // Send
         curl_easy_setopt(curlHandle, CURLOPT_SSL_VERIFYPEER, true);
-        const auto& res = curl_easy_perform(curlHandle);
+        CURLcode res = curl_easy_perform(curlHandle);
         long curlHttpResponseCode = 0;
         curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, &curlHttpResponseCode);
 

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -35,7 +35,7 @@ namespace PlayFab
 
         // First event is just a stub which is used only to maintain the initial consistency of m_head/m_tail.
         // It is immediately considered already consumed.
-        unsigned long long index = eventIndex->load(std::memory_order_relaxed);
+        auto index = static_cast<uint64_t>(eventIndex->load(std::memory_order_relaxed));
         PlayFabEventPacket* firstEvent = CreateEventPacket(buffer, index, nullptr);
 
         tail = firstEvent;
@@ -97,7 +97,7 @@ namespace PlayFab
 
         // create an event packet, set it to the tail->next and move the tail
 
-        const unsigned long long currentEventIndex = eventIndex->fetch_add(1, std::memory_order_relaxed);
+        const auto currentEventIndex = static_cast<const uint64_t>(eventIndex->fetch_add(1, std::memory_order_relaxed));
         PlayFabEventPacket* event = CreateEventPacket(reinterpret_cast<uint8_t*>(eventStart), currentEventIndex, std::move(request));
         tailPtr->next.store(event, std::memory_order_release);
         tail = event;

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -22,7 +22,7 @@ namespace PlayFab
 
     PlayFabEventBuffer::PlayFabEventBuffer(
         const size_t bufferSize) 
-        : 
+        :
         buffMask(AdjustBufferSize(bufferSize) - 1),
         bufferArray(std::unique_ptr<uint8_t[]>(new uint8_t[buffMask + 1])),
         buffStart((uint64_t)(bufferArray.get())),
@@ -35,7 +35,7 @@ namespace PlayFab
 
         // First event is just a stub which is used only to maintain the initial consistency of m_head/m_tail.
         // It is immediately considered already consumed.
-        auto index = static_cast<uint64_t>(eventIndex->load(std::memory_order_relaxed));
+        uint64_t index = eventIndex->load(std::memory_order_relaxed);
         PlayFabEventPacket* firstEvent = CreateEventPacket(buffer, index, nullptr);
 
         tail = firstEvent;
@@ -97,7 +97,7 @@ namespace PlayFab
 
         // create an event packet, set it to the tail->next and move the tail
 
-        const auto currentEventIndex = static_cast<const uint64_t>(eventIndex->fetch_add(1, std::memory_order_relaxed));
+        uint64_t currentEventIndex = eventIndex->fetch_add(1, std::memory_order_relaxed);
         PlayFabEventPacket* event = CreateEventPacket(reinterpret_cast<uint8_t*>(eventStart), currentEventIndex, std::move(request));
         tailPtr->next.store(event, std::memory_order_release);
         tail = event;

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -35,7 +35,7 @@ namespace PlayFab
 
         // First event is just a stub which is used only to maintain the initial consistency of m_head/m_tail.
         // It is immediately considered already consumed.
-        auto index = eventIndex->load(std::memory_order_relaxed);
+        unsigned long long index = eventIndex->load(std::memory_order_relaxed);
         PlayFabEventPacket* firstEvent = CreateEventPacket(buffer, index, nullptr);
 
         tail = firstEvent;
@@ -97,7 +97,7 @@ namespace PlayFab
 
         // create an event packet, set it to the tail->next and move the tail
 
-        const auto currentEventIndex = eventIndex->fetch_add(1, std::memory_order_relaxed);
+        const unsigned long long currentEventIndex = eventIndex->fetch_add(1, std::memory_order_relaxed);
         PlayFabEventPacket* event = CreateEventPacket(reinterpret_cast<uint8_t*>(eventStart), currentEventIndex, std::move(request));
         tailPtr->next.store(event, std::memory_order_release);
         tail = event;

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -107,7 +107,7 @@ namespace PlayFab
 
             // pipeline failed to intake the event, create a response
             std::shared_ptr<const PlayFabEmitEventRequest> playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(request);
-            auto playFabEmitEventResponse = std::shared_ptr<PlayFabEmitEventResponse>(new PlayFabEmitEventResponse());
+            auto playFabEmitEventResponse = std::make_shared<PlayFabEmitEventResponse>();
             playFabEmitEventResponse->emitEventResult = emitResult;
 
             // call an emit event callback
@@ -260,7 +260,7 @@ namespace PlayFab
         try
         {
             // batch was successfully sent out, find it in the batch tracking map using customData pointer as a key
-            auto foundBatchIterator = this->batchesInFlight.find(customData);
+            const auto foundBatchIterator = this->batchesInFlight.find(customData);
             if (foundBatchIterator == this->batchesInFlight.end())
             {
                 LOG_PIPELINE("Untracked batch was returned to EventsAPI.WriteEvents callback"); // normally this never happens
@@ -275,7 +275,7 @@ namespace PlayFab
                     std::shared_ptr<const PlayFabEmitEventRequest> playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
                     auto playFabEmitEventResponse = std::shared_ptr<PlayFabEmitEventResponse>(new PlayFabEmitEventResponse());
                     playFabEmitEventResponse->emitEventResult = EmitEventResult::Success;
-                    std::shared_ptr<PlayFabError> playFabError = std::shared_ptr<PlayFabError>(new PlayFabError());
+                    auto playFabError = std::make_shared<PlayFabError>();
                     playFabError->HttpCode = 200;
                     playFabError->ErrorCode = PlayFabErrorCode::PlayFabErrorSuccess;
                     playFabEmitEventResponse->playFabError = playFabError;
@@ -302,7 +302,7 @@ namespace PlayFab
         try
         {
             // batch wasn't sent out due to an error, find it in the batch tracking map using customData pointer as a key
-            auto foundBatchIterator = this->batchesInFlight.find(customData);
+            const auto foundBatchIterator = this->batchesInFlight.find(customData);
             if (foundBatchIterator == this->batchesInFlight.end())
             {
                 LOG_PIPELINE("Untracked batch was returned to EventsAPI.WriteEvents callback"); // normally this never happens

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -106,7 +106,7 @@ namespace PlayFab
             }
 
             // pipeline failed to intake the event, create a response
-            const auto& playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(request);
+            std::shared_ptr<const PlayFabEmitEventRequest> playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(request);
             auto playFabEmitEventResponse = std::shared_ptr<PlayFabEmitEventResponse>(new PlayFabEmitEventResponse());
             playFabEmitEventResponse->emitEventResult = emitResult;
 
@@ -272,10 +272,10 @@ namespace PlayFab
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
                 {
-                    const auto& playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
+                    std::shared_ptr<const PlayFabEmitEventRequest> playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
                     auto playFabEmitEventResponse = std::shared_ptr<PlayFabEmitEventResponse>(new PlayFabEmitEventResponse());
                     playFabEmitEventResponse->emitEventResult = EmitEventResult::Success;
-                    auto playFabError = std::shared_ptr<PlayFabError>(new PlayFabError());
+                    std::shared_ptr<PlayFabError> playFabError = std::shared_ptr<PlayFabError>(new PlayFabError());
                     playFabError->HttpCode = 200;
                     playFabError->ErrorCode = PlayFabErrorCode::PlayFabErrorSuccess;
                     playFabEmitEventResponse->playFabError = playFabError;
@@ -314,7 +314,7 @@ namespace PlayFab
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
                 {
-                    const auto& playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
+                    std::shared_ptr<const PlayFabEmitEventRequest> playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
                     auto playFabEmitEventResponse = std::shared_ptr<PlayFabEmitEventResponse>(new PlayFabEmitEventResponse());
                     playFabEmitEventResponse->emitEventResult = EmitEventResult::Success;
                     playFabEmitEventResponse->playFabError = std::shared_ptr<PlayFabError>(new PlayFabError(error));

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -212,7 +212,7 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
-        auto requestUrl = GetUrl(requestTask);
+        const auto& requestUrl = GetUrl(requestTask);
 
         NSURL* url = [NSURL URLWithString:[NSString stringWithUTF8String:requestUrl.c_str()]];
         NSURLSessionConfiguration* config = [NSURLSessionConfiguration defaultSessionConfiguration];

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -222,7 +222,7 @@ namespace PlayFab
         urlRequest.HTTPMethod = @"POST";
         SetPredefinedHeaders(requestTask, (__bridge void*)urlRequest);
 
-        auto headers = requestContainer.GetHeaders();
+        const auto& headers = requestContainer.GetRequestHeaders();
         if (headers.size() > 0)
         {
             for (auto const &obj : headers)
@@ -323,7 +323,7 @@ namespace PlayFab
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
 
-        auto callback = requestContainer.GetCallback();
+        const auto& callback = requestContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(requestContainer.responseJson.get("code", Json::Value::null).asInt(),

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -127,7 +127,7 @@ namespace PlayFab
         reportErrorAsSuccessHeader.wstrHeaderValue = L"true";
         headers.push_back(std::move(reportErrorAsSuccessHeader));
 
-        const auto& reqHeaders = reqContainer.GetHeaders();
+        const std::unordered_map<std::string, std::string> reqHeaders = reqContainer.GetHeaders();
 
         if (reqHeaders.size() > 0)
         {
@@ -174,8 +174,8 @@ namespace PlayFab
 
         const HRESULT res = postEventRequest.GetResult();
         const DWORD status = postEventRequest.GetStatus();
-        const auto& response = postEventRequest.GetData();
-        const auto& responseRequestId = postEventRequest.GetResponseRequestId();
+        const std::wstring response = postEventRequest.GetData();
+        const std::wstring responseRequestId = postEventRequest.GetResponseRequestId();
 
         reqContainer.responseString = std::string(response.begin(), response.end());
         reqContainer.errorWrapper.RequestId = std::string(responseRequestId.begin(), responseRequestId.end());
@@ -233,7 +233,7 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        const auto& callback = reqContainer.GetCallback();
+        CallRequestContainerCallback callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -127,7 +127,7 @@ namespace PlayFab
         reportErrorAsSuccessHeader.wstrHeaderValue = L"true";
         headers.push_back(std::move(reportErrorAsSuccessHeader));
 
-        auto reqHeaders = reqContainer.GetHeaders();
+        const auto& reqHeaders = reqContainer.GetHeaders();
 
         if (reqHeaders.size() > 0)
         {
@@ -233,7 +233,7 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        auto callback = reqContainer.GetCallback();
+        const auto& callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -27,8 +27,8 @@ namespace PlayFab
 
     std::shared_ptr<IPlayFabPlugin> PlayFabPluginManager::GetPluginInternal(const PlayFabPluginContract contract, const std::string& instanceName)
     {
-        const auto key = std::make_pair(contract, instanceName);
-        auto pluginEntry = plugins.find(key);
+        std::pair<PlayFabPluginContract, std::string> key = std::make_pair(contract, instanceName);
+        const auto& pluginEntry = plugins.find(key);
         if (pluginEntry == plugins.end())
         {
             // Requested plugin is not in the cache, create the default one
@@ -57,8 +57,8 @@ namespace PlayFab
 
     void PlayFabPluginManager::SetPluginInternal(std::shared_ptr<IPlayFabPlugin> plugin, const PlayFabPluginContract contract, const std::string& instanceName)
     {
-        const auto key = std::make_pair(contract, instanceName);
-        auto pluginEntry = plugins.find(key);
+        std::pair<PlayFabPluginContract, std::string> key = std::make_pair(contract, instanceName);
+        const auto& pluginEntry = plugins.find(key);
         if (pluginEntry == plugins.end())
         {
             plugins.insert({ key, std::move(plugin) });

--- a/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -28,7 +28,7 @@ namespace PlayFab
     std::shared_ptr<IPlayFabPlugin> PlayFabPluginManager::GetPluginInternal(const PlayFabPluginContract contract, const std::string& instanceName)
     {
         std::pair<PlayFabPluginContract, std::string> key = std::make_pair(contract, instanceName);
-        const auto& pluginEntry = plugins.find(key);
+        const auto pluginEntry = plugins.find(key);
         if (pluginEntry == plugins.end())
         {
             // Requested plugin is not in the cache, create the default one
@@ -58,7 +58,7 @@ namespace PlayFab
     void PlayFabPluginManager::SetPluginInternal(std::shared_ptr<IPlayFabPlugin> plugin, const PlayFabPluginContract contract, const std::string& instanceName)
     {
         std::pair<PlayFabPluginContract, std::string> key = std::make_pair(contract, instanceName);
-        const auto& pluginEntry = plugins.find(key);
+        const auto pluginEntry = plugins.find(key);
         if (pluginEntry == plugins.end())
         {
             plugins.insert({ key, std::move(plugin) });

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -415,7 +415,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        const std::unordered_map<std::string, std::string> callback = reqContainer.GetCallback();
+        CallRequestContainerCallback callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -255,7 +255,7 @@ namespace PlayFab
                                         }
 
                                         // Allocate space for the buffer
-                                        std::unique_ptr<char[]> outBuffer = std::unique_ptr<char[]>(new char[dwSize + 1]);
+                                        auto outBuffer = std::unique_ptr<char[]>(new char[dwSize + 1]);
                                         if (!outBuffer)
                                         {
                                             SetErrorInfo(reqContainer, "Out of memory, failed to allocate a buffer to read a data block in HTTP response");

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -190,7 +190,7 @@ namespace PlayFab
                     {
                         // Add HTTP headers
                         SetPredefinedHeaders(reqContainer, hRequest);
-                        auto headers = reqContainer.GetRequestHeaders();
+                        const auto& headers = reqContainer.GetRequestHeaders();
                         if (headers.size() > 0)
                         {
                             for (auto const& obj : headers)
@@ -255,7 +255,7 @@ namespace PlayFab
                                         }
 
                                         // Allocate space for the buffer
-                                        auto outBuffer = std::unique_ptr<char[]>(new char[dwSize + 1]);
+                                        std::unique_ptr<char[]> outBuffer = std::unique_ptr<char[]>(new char[dwSize + 1]);
                                         if (!outBuffer)
                                         {
                                             SetErrorInfo(reqContainer, "Out of memory, failed to allocate a buffer to read a data block in HTTP response");
@@ -415,7 +415,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        auto callback = reqContainer.GetCallback();
+        const auto& callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -190,7 +190,7 @@ namespace PlayFab
                     {
                         // Add HTTP headers
                         SetPredefinedHeaders(reqContainer, hRequest);
-                        const auto& headers = reqContainer.GetRequestHeaders();
+                        const std::unordered_map<std::string, std::string> headers = reqContainer.GetRequestHeaders();
                         if (headers.size() > 0)
                         {
                             for (auto const& obj : headers)
@@ -415,7 +415,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::HandleResults(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         CallRequestContainer& reqContainer = *requestContainer;
-        const auto& callback = reqContainer.GetCallback();
+        const std::unordered_map<std::string, std::string> callback = reqContainer.GetCallback();
         if (callback != nullptr)
         {
             callback(

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -231,7 +231,7 @@ namespace PlayFab
 
             for(const QosServer& server :result.QosServers)
             {
-                api->regionMap[server.Region] = move(server.ServerUrl);
+                api->regionMap[server.Region] = server.ServerUrl;
             }
 
             api->listQosServersCompleted = true;

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -48,10 +48,10 @@ namespace PlayFab
             WriteEventsResponse outResult;
             if (ValidateResult(outResult, container))
             {
-                const auto& internalPtr = container.successCallback.get();
-                if (internalPtr != nullptr)
+                std::shared_ptr<void> internalPtr = container.successCallback;
+                if (internalPtr.get() != nullptr)
                 {
-                    const auto& callback = (*static_cast<ProcessApiCallback<WriteEventsResponse> *>(internalPtr));
+                    const auto& callback = *static_cast<ProcessApiCallback<WriteEventsResponse> *>(internalPtr.get());
                     callback(outResult, container.GetCustomData());
                 }
             }
@@ -65,13 +65,13 @@ namespace PlayFab
         )
         {
             IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-            const auto& requestJson = request.ToJson();
+            Json::Value requestJson = request.ToJson();
             std::string jsonAsString = requestJson.toStyledString();
 
             std::unordered_map<std::string, std::string> headers;
             headers.emplace("X-EntityToken", request.authenticationContext == nullptr ? PlayFabSettings::entityToken : request.authenticationContext->entityToken);
 
-            std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+            auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
                 "/Event/WriteTelemetryEvents",
                 headers,
                 jsonAsString,

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -229,10 +229,9 @@ namespace PlayFab
             // Custom data received is a pointer to our api object
             PlayFabQoSApi* api = reinterpret_cast<PlayFabQoSApi*>(customData);
 
-            std::list<QosServer> a = result.QosServers;
-            for (auto it = a.begin(); it != a.end(); ++it)
+            for(const QosServer& server :result.QosServers)
             {
-                api->regionMap[it->Region] = move(it->ServerUrl);
+                api->regionMap[server.Region] = move(server.ServerUrl);
             }
 
             api->listQosServersCompleted = true;

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -48,10 +48,10 @@ namespace PlayFab
             WriteEventsResponse outResult;
             if (ValidateResult(outResult, container))
             {
-                const auto internalPtr = container.successCallback.get();
+                const auto& internalPtr = container.successCallback.get();
                 if (internalPtr != nullptr)
                 {
-                    const auto callback = (*static_cast<ProcessApiCallback<WriteEventsResponse> *>(internalPtr));
+                    const auto& callback = (*static_cast<ProcessApiCallback<WriteEventsResponse> *>(internalPtr));
                     callback(outResult, container.GetCustomData());
                 }
             }
@@ -65,13 +65,13 @@ namespace PlayFab
         )
         {
             IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-            const auto requestJson = request.ToJson();
+            const auto& requestJson = request.ToJson();
             std::string jsonAsString = requestJson.toStyledString();
 
             std::unordered_map<std::string, std::string> headers;
             headers.emplace("X-EntityToken", request.authenticationContext == nullptr ? PlayFabSettings::entityToken : request.authenticationContext->entityToken);
 
-            auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+            std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
                 "/Event/WriteTelemetryEvents",
                 headers,
                 jsonAsString,
@@ -229,7 +229,7 @@ namespace PlayFab
             // Custom data received is a pointer to our api object
             PlayFabQoSApi* api = reinterpret_cast<PlayFabQoSApi*>(customData);
 
-            auto a = result.QosServers;
+            std::list<QosServer> a = result.QosServers;
             for (auto it = a.begin(); it != a.end(); ++it)
             {
                 api->regionMap[it->Region] = move(it->ServerUrl);

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -171,7 +171,7 @@ namespace PlayFab
 
             if (selectResult > 0)
             {
-                int recvResult = recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen);
+                size_t recvResult = recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen);
                 if (recvResult < 0)
                 {
                     return platformSpecificError();

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -107,7 +107,7 @@ namespace PlayFab
                 return GetLastErrorCode();
             }
 
-            auto inAddr = (struct in_addr*) he->h_addr_list[0];
+            in_addr* inAddr = (struct in_addr*) he->h_addr_list[0];
 
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
             if (inAddr->S_un.S_addr == 0)
@@ -166,12 +166,12 @@ namespace PlayFab
             FD_CLR(0, &socketSet);
             FD_SET(s, &socketSet);
 
-            auto fd_max = s+1;
+            int fd_max = s+1;
             int selectResult = select(fd_max, &socketSet, nullptr, nullptr, &timeOutVal);
 
             if (selectResult > 0)
             {
-                auto recvResult = recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen);
+                int recvResult = recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen);
                 if (recvResult < 0)
                 {
                     return platformSpecificError();

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -107,7 +107,7 @@ namespace PlayFab
                 return GetLastErrorCode();
             }
 
-            in_addr* inAddr = (struct in_addr*) he->h_addr_list[0];
+            in_addr* inAddr = reinterpret_cast<in_addr*>(he->h_addr_list[0]);
 
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
             if (inAddr->S_un.S_addr == 0)
@@ -166,17 +166,16 @@ namespace PlayFab
             FD_CLR(0, &socketSet);
             FD_SET(s, &socketSet);
 
-            int fd_max = s+1;
-            int selectResult = select(fd_max, &socketSet, nullptr, nullptr, &timeOutVal);
+            int selectResult = select(s+1, &socketSet, nullptr, nullptr, &timeOutVal);
 
             if (selectResult > 0)
             {
-                size_t recvResult = recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen);
+                int recvResult = static_cast<int>(recvfrom(s, buf, buflen, 0, (struct sockaddr *) &siOther, &slen));
                 if (recvResult < 0)
                 {
                     return platformSpecificError();
                 }
-                return static_cast<int>(recvResult);
+                return recvResult;
             }
             else if (selectResult < 0)
             {

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -48,7 +48,7 @@ namespace PlayFabUnit
         request.CreateAccount = true;
 
         // store current (valid) title id
-        auto validTitleId = PlayFabSettings::titleId;
+        const std::string validTitleId = PlayFabSettings::titleId;
 
         // set invalid title id
         PlayFabSettings::titleId = "";

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -23,7 +23,7 @@ namespace PlayFabUnit
     {
         QoS::PlayFabQoSApi api;
 
-        auto result = api.GetQoSResult(5, 200);
+        QoS::QoSResult result = api.GetQoSResult(5, 200);
 
         if (result.errorCode == 0)
             testContext.Pass();
@@ -93,8 +93,8 @@ namespace PlayFabUnit
     
     void PlayFabEventTest::EmitEventCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response)
     {
-        auto pfEvent = std::dynamic_pointer_cast<const PlayFab::PlayFabEvent>(event);
-        auto pfResponse = std::dynamic_pointer_cast<const PlayFab::PlayFabEmitEventResponse>(response);
+        std::shared_ptr<const PlayFab::PlayFabEvent> pfEvent = std::dynamic_pointer_cast<const PlayFab::PlayFabEvent>(event);
+        std::shared_ptr<const PlayFab::PlayFabEmitEventResponse> pfResponse = std::dynamic_pointer_cast<const PlayFab::PlayFabEmitEventResponse>(response);
 
         if (pfResponse->playFabError != nullptr)
         {
@@ -150,7 +150,7 @@ namespace PlayFabUnit
         // They will be batched up according to pipeline's settings
         for (int i = 0; i < eventEmitCount; i++)
         {
-            auto event = MakeEvent(i, eventType);
+            std::unique_ptr<PlayFab::PlayFabEvent> event = MakeEvent(i, eventType);
             (*api)->EmitEvent(std::move(event), EmitEventCallback);
         }
     }
@@ -281,8 +281,8 @@ namespace PlayFabUnit
         std::shared_ptr<PlayFabEventAPI*> api = std::make_shared<PlayFabEventAPI*>(new PlayFabEventAPI()); // create Event API instance
 
         // adjust some pipeline settings
-        auto pipeline = std::dynamic_pointer_cast<PlayFab::PlayFabEventPipeline>((*api)->GetEventRouter()->GetPipelines().at(PlayFab::EventPipelineKey::PlayFabTelemetry)); // get non-playstream pipeline
-        auto settings = pipeline->GetSettings(); // get pipeline's settings
+        std::shared_ptr<PlayFab::PlayFabEventPipeline>  pipeline = std::dynamic_pointer_cast<PlayFab::PlayFabEventPipeline>((*api)->GetEventRouter()->GetPipelines().at(PlayFab::EventPipelineKey::PlayFabTelemetry)); // get non-playstream pipeline
+        std::shared_ptr<PlayFab::PlayFabEventPipelineSettings>  settings = pipeline->GetSettings(); // get pipeline's settings
         settings->maximalBatchWaitTime = maxBatchWaitTime; // incomplete batch expiration in seconds
         settings->maximalNumberOfItemsInBatch = maxItemsInBatch; // number of events in a batch
         settings->maximalNumberOfBatchesInFlight = maxBatchesInFlight; // maximal number of batches processed simultaneously by a transport plugin before taking next events from the buffer

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
@@ -21,8 +21,8 @@ namespace PlayFabUnit
         GetPlayerProfileRequest profileRequest;
         profileRequest.authenticationContext = result.authenticationContext;
 
-        auto user1ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user1ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
         (*multiUser1ClientApi)->GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
     }
     void PlayFabTestMultiUserInstance::MultiUserLogin1Failure(const PlayFabError& error, void* customData)
@@ -45,8 +45,8 @@ namespace PlayFabUnit
         GetPlayerProfileRequest profileRequest;
         profileRequest.authenticationContext = result.authenticationContext;
 
-        auto user2ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user2ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
         (*multiUser2ClientApi)->GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
     }
     void PlayFabTestMultiUserInstance::MultiUserLogin2Failure(const PlayFabError& error, void* customData)
@@ -71,16 +71,16 @@ namespace PlayFabUnit
         user1LoginRequest.CustomId = "test_MultiInstance1";
         user1LoginRequest.CreateAccount = true;
 
-        auto user1LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user1LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
         (*multiUser1ClientApi)->LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
 
         LoginWithCustomIDRequest user2LoginRequest;
         user2LoginRequest.CustomId = "test_MultiInstance2";
         user2LoginRequest.CreateAccount = true;
 
-        auto user2LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user2LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
         (*multiUser2ClientApi)->LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
     }
 

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
@@ -20,8 +20,8 @@ namespace PlayFabUnit
         GetPlayerProfileRequest profileRequest;
         profileRequest.authenticationContext = result.authenticationContext;
 
-        auto user1ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user1ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
     }
     void PlayFabTestMultiUserStatic::MultiUserLogin1Failure(const PlayFabError& error, void* customData)
@@ -44,8 +44,8 @@ namespace PlayFabUnit
         GetPlayerProfileRequest profileRequest;
         profileRequest.authenticationContext = result.authenticationContext;
 
-        auto user2ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user2ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
     }
     void PlayFabTestMultiUserStatic::MultiUserLogin2Failure(const PlayFabError& error, void* customData)
@@ -70,16 +70,16 @@ namespace PlayFabUnit
         user1LoginRequest.CustomId = "test_MultiStatic1";
         user1LoginRequest.CreateAccount = true;
 
-        auto user1LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user1LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user1LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
 
         LoginWithCustomIDRequest user2LoginRequest;
         user2LoginRequest.CustomId = "test_MultiStatic2";
         user2LoginRequest.CreateAccount = true;
 
-        auto user2LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
-        auto user2LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
+        const auto& user2LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
     }
 

--- a/source/test/TestApp/TestCase.h
+++ b/source/test/TestApp/TestCase.h
@@ -10,10 +10,11 @@ namespace PlayFabUnit
 {
     struct TestContext;
 
+    typedef std::list<std::shared_ptr<TestContext*>> TestList;
+
     class TestCase
     {
         public:
-            typedef std::list<std::shared_ptr<TestContext*>> TestList;
 
             TestCase()
             {
@@ -86,7 +87,7 @@ namespace PlayFabUnit
             template <class T> void AddTest(std::string name, void(T::*testCaseFunc)(TestContext&))
             {
                 T* testCase = reinterpret_cast<T*>(this);
-                auto testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);
+                const auto& testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);
                 std::shared_ptr<TestContext*> testContext = std::make_shared<TestContext*>(new TestContext(testCase, name, testFunc));
 
                 (*testList)->push_back(testContext);

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -28,7 +28,7 @@ namespace PlayFabUnit
             return;
 
         // Add the tests from the given test case.
-        auto testCaseTests = testCase.GetTests();
+        std::shared_ptr<TestList*> testCaseTests = testCase.GetTests();
         suiteTests.splice(suiteTests.end(), **testCaseTests);
     }
 
@@ -59,7 +59,7 @@ namespace PlayFabUnit
             // Tick the test.
             while (TestActiveState::ACTIVE == test->activeState)
             {
-                auto timeNow = TestTimeNow();
+                PlayFabUnit::TimePoint timeNow = TestTimeNow();
                 bool timeExpired = (timeNow - test->startTime) > TEST_TIMEOUT_DURATION;
 
                 if ((TestActiveState::READY != test->activeState) && !timeExpired) // Not finished & not timed out

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -38,7 +38,7 @@ namespace PlayFab
     {
 <%- getRequestActions("        ", apiCall, false) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-        const auto& requestJson = request.ToJson();
+        const Json::Value requestJson = request.ToJson();
         std::string jsonAsString = requestJson.toStyledString();
 
         std::unordered_map<std::string, std::string> headers;

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -44,7 +44,7 @@ namespace PlayFab
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall, false) %>);
 
-        std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+        auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
@@ -68,10 +68,10 @@ namespace PlayFab
         if (ValidateResult(outResult, container))
         {
 <%- getResultActions("            ", apiCall, false) %>
-            const auto& internalPtr = container.successCallback.get();
-            if (internalPtr != nullptr)
+            std::shared_ptr<void> internalPtr = container.successCallback;
+            if (internalPtr.get() != nullptr)
             {
-                const auto& callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                const auto& callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr.get()));
                 callback(outResult, container.GetCustomData());
             }
         }

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -38,13 +38,13 @@ namespace PlayFab
     {
 <%- getRequestActions("        ", apiCall, false) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-        const auto requestJson = request.ToJson();
+        const auto& requestJson = request.ToJson();
         std::string jsonAsString = requestJson.toStyledString();
 
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall, false) %>);
 
-        auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+        std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
@@ -68,10 +68,10 @@ namespace PlayFab
         if (ValidateResult(outResult, container))
         {
 <%- getResultActions("            ", apiCall, false) %>
-            const auto internalPtr = container.successCallback.get();
+            const auto& internalPtr = container.successCallback.get();
             if (internalPtr != nullptr)
             {
-                const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                const auto& callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
                 callback(outResult, container.GetCustomData());
             }
         }

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -95,14 +95,14 @@ namespace PlayFab
     {
 <%- getRequestActions("        ", apiCall, true) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-        const auto& requestJson = request.ToJson();
+        const Json::Value requestJson = request.ToJson();
         std::string jsonAsString = requestJson.toStyledString();
 
         std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = request.authenticationContext == nullptr ? this->GetOrCreateAuthenticationContext() : request.authenticationContext;
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall, true) %>);
 
-        std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+        auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -95,14 +95,14 @@ namespace PlayFab
     {
 <%- getRequestActions("        ", apiCall, true) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-        const auto requestJson = request.ToJson();
+        const auto& requestJson = request.ToJson();
         std::string jsonAsString = requestJson.toStyledString();
 
-        auto authenticationContext = request.authenticationContext == nullptr ? this->GetOrCreateAuthenticationContext() : request.authenticationContext;
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = request.authenticationContext == nullptr ? this->GetOrCreateAuthenticationContext() : request.authenticationContext;
         std::unordered_map<std::string, std::string> headers;
         headers.emplace(<%- getAuthParams(apiCall, true) %>);
 
-        auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
+        std::unique_ptr<CallRequestContainer> reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
             "<%- apiCall.url %>",
             headers,
             jsonAsString,
@@ -127,10 +127,10 @@ namespace PlayFab
         if (ValidateResult(outResult, container))
         {
 <%- getResultActions("            ", apiCall, true) %>
-            const auto internalPtr = container.successCallback.get();
+            const auto& internalPtr = container.successCallback.get();
             if (internalPtr != nullptr)
             {
-                const auto callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                const auto& callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
                 callback(outResult, container.GetCustomData());
             }
         }
@@ -144,7 +144,7 @@ namespace PlayFab
 
     void PlayFabClientInstanceAPI::MultiStepClientLogin(bool needsAttribution)
     {
-        auto apiSettings = this->GetSettings();
+        const auto& apiSettings = this->GetSettings();
         if (apiSettings == nullptr)
         {
             if (needsAttribution && !PlayFabSettings::disableAdvertising && PlayFabSettings::advertisingIdType.length() > 0 && PlayFabSettings::advertisingIdValue.length() > 0)

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -127,10 +127,10 @@ namespace PlayFab
         if (ValidateResult(outResult, container))
         {
 <%- getResultActions("            ", apiCall, true) %>
-            const auto& internalPtr = container.successCallback.get();
-            if (internalPtr != nullptr)
+            std::shared_ptr<void> internalPtr = container.successCallback;
+            if (internalPtr.get() != nullptr)
             {
-                const auto& callback = (*static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr));
+                const auto& callback = *static_cast<ProcessApiCallback<<%- apiCall.result %>> *>(internalPtr.get());
                 callback(outResult, container.GetCustomData());
             }
         }
@@ -144,7 +144,7 @@ namespace PlayFab
 
     void PlayFabClientInstanceAPI::MultiStepClientLogin(bool needsAttribution)
     {
-        const auto& apiSettings = this->GetSettings();
+        std::shared_ptr<PlayFab::PlayFabApiSettings> apiSettings = this->GetSettings();
         if (apiSettings == nullptr)
         {
             if (needsAttribution && !PlayFabSettings::disableAdvertising && PlayFabSettings::advertisingIdType.length() > 0 && PlayFabSettings::advertisingIdValue.length() > 0)


### PR DESCRIPTION
Updating Auto correctness standards in our codebase.

Auto may be used in only 1 of 3 cases
    1.) the Class is directly being called out/allocated/what not on the right hand side of the equals sign
        NOTE: This does NOT include Getter functions/Builder functions. There are cases where getter functions may reference a more general object in the method name, rather than the specific (i.e. PlayFabSettings or even PlayFabSharedSettings instead of GetSettings).
    2.) iterators (may be const & or not, depends on what you are doing with this iterator)
    3.) binds (prefer const auto & for these unless you need to be changing a bind on the fly, but that sounds like a discussion for another time)

EDIT: 
    This also contains some type changes that popped up extra warnings on other platforms (mostly either Android Studio or Xcode marking deprecation's as warnings).