### PR TITLE
Instance signature and data-safety overhaul

### DIFF
--- a/make.js
+++ b/make.js
@@ -122,9 +122,9 @@ function getAuthParams(apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return "authKey, authValue";
     switch (apiCall.auth) {
-        case "EntityToken": return "\"X-EntityToken\", request.authenticationContext == nullptr ? " + (isInstanceApi ? "this->GetOrCreateAuthenticationContext()->" : "PlayFabSettings::") + "entityToken : request.authenticationContext->entityToken";
-        case "SessionTicket": return "\"X-Authorization\", request.authenticationContext == nullptr ? " + (isInstanceApi ? "this->GetOrCreateAuthenticationContext()->" : "PlayFabSettings::") + "clientSessionTicket : request.authenticationContext->clientSessionTicket";
-        case "SecretKey": return "\"X-SecretKey\", request.authenticationContext == nullptr ? " + (isInstanceApi ? "this->GetOrCreateAuthenticationContext()->" : "PlayFabSettings::") + "developerSecretKey : request.authenticationContext->developerSecretKey";
+        case "EntityToken": return "\"X-EntityToken\", context->entityToken";
+        case "SessionTicket": return "\"X-Authorization\", context->clientSessionTicket";
+        case "SecretKey": return "\"X-SecretKey\", settings->developerSecretKey";
     }
     throw Error("getAuthParams: Unknown auth type: " + apiCall.auth + " for " + apiCall.name);
 }
@@ -237,127 +237,42 @@ function getPropertySafeName(property) {
 function getRequestActions(tabbing, apiCall, isInstanceApi) {
     //TODO Bug 6594: add to this titleId check. 
     // If this titleId does not exist we should be throwing an error informing the user MUST have a titleId.
-    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult") {
-        var output;
-        if (isInstanceApi) {
-            output = tabbing + "auto apiSettings = this->GetSettings();\n"
-                + tabbing + "if (apiSettings == nullptr)\n"
-                + tabbing + "{\n"
-                + tabbing + "    if (PlayFabSettings::titleId.length() > 0)\n"
-                + tabbing + "    {\n"
-                + tabbing + "        request.TitleId = PlayFabSettings::titleId;\n"
-                + tabbing + "    }\n"
-                + tabbing + "}\n"
-                + tabbing + "else\n"
-                + tabbing + "{\n"
-                + tabbing + "    if (apiSettings->titleId.length() > 0)\n"
-                + tabbing + "    {\n"
-                + tabbing + "        request.TitleId = apiSettings->titleId;\n"
-                + tabbing + "    }\n"
-                + tabbing + "}\n";
-        }
-        else {
-            output = tabbing + "if (PlayFabSettings::titleId.length() > 0)\n"
-                + tabbing + "{\n"
-                + tabbing + "    request.TitleId = PlayFabSettings::titleId;\n"
-                + tabbing + "}\n";
-        }
-
-        return output;
-    }
-
-    if (apiCall.url === "/Authentication/GetEntityToken") {
-        var authContext;
-        if (isInstanceApi) {
-            authContext = "authenticationContext->";
-        }
-        else {
-            authContext = "PlayFabSettings::";
-        }
-
-        return tabbing + "std::string authKey, authValue;\n"
-            + tabbing + "if (request.authenticationContext != nullptr) {\n"
-            + tabbing + "    if (request.authenticationContext->entityToken.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-EntityToken\"; authValue = request.authenticationContext->entityToken;\n"
-            + tabbing + "    }\n"
-            + tabbing + "    else if (request.authenticationContext->clientSessionTicket.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-Authorization\"; authValue = request.authenticationContext->clientSessionTicket;\n"
-            + tabbing + "    }\n"
-            + "    #if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)\n"
-            + tabbing + "    else if (request.authenticationContext->developerSecretKey.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-SecretKey\"; authValue = request.authenticationContext->developerSecretKey;\n"
-            + tabbing + "    }\n"
-            + "    #endif\n"
-            + tabbing + "}\n"
-            + tabbing + "else {\n"
-            + (isInstanceApi ? tabbing + "    std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
-            + tabbing + "    if (" + authContext + "entityToken.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-EntityToken\"; authValue = " + authContext + "entityToken;\n"
-            + tabbing + "    }\n"
-            + tabbing + "    else if (" + authContext + "clientSessionTicket.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-Authorization\"; authValue = " + authContext + "clientSessionTicket;\n"
-            + tabbing + "    }\n"
-            + "    #if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)\n"
-            + tabbing + "    else if (" + authContext + "developerSecretKey.length() > 0) {\n"
-            + tabbing + "        authKey = \"X-SecretKey\"; authValue = " + authContext + "developerSecretKey;\n"
-            + tabbing + "    }\n"
-            + "    #endif\n"
+    if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
+        return tabbing + "if (request.TitleId.empty())\n"
+            + tabbing + "{\n"
+            + tabbing + "    request.TitleId = settings->titleId;\n"
             + tabbing + "}\n";
-    }
+
+    if (apiCall.url === "/Authentication/GetEntityToken")
+        return tabbing + "std::string authKey, authValue;\n" +
+            tabbing + "if (context->entityToken.length() > 0) {\n" +
+            tabbing + "    authKey = \"X-EntityToken\"; authValue = context->entityToken;\n" +
+            tabbing + "}\n" +
+            tabbing + "else if (context->clientSessionTicket.length() > 0) {\n" +
+            tabbing + "    authKey = \"X-Authorization\"; authValue = context->clientSessionTicket;\n" +
+            tabbing + "}\n" +
+            "#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)\n" +
+            tabbing + "else if (settings->developerSecretKey.length() > 0) {\n" +
+            tabbing + "    authKey = \"X-SecretKey\"; authValue = settings->developerSecretKey;\n" +
+            tabbing + "}\n" +
+            "#endif\n";
 
     return "";
 }
 
 function getResultActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
-        return tabbing + "if (outResult.EntityToken.length() > 0)"
-            + tabbing + "{\n"
-            + tabbing + "    " + (isInstanceApi ? "this->GetOrCreateAuthenticationContext()->" : "PlayFabSettings::") + "entityToken = outResult.EntityToken;\n"
-            + tabbing + "}\n";
-    if (apiCall.result === "LoginResult") {
-        var authContext;
-        if (isInstanceApi) {
-            authContext = "authenticationContext->";
-        }
-        else {
-            authContext = "PlayFabSettings::";
-        }
-
-        return tabbing + "if (outResult.SessionTicket.length() > 0)\n"
-            + tabbing + "{\n"
-            + tabbing + "    outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n"
-            + tabbing + "    outResult.authenticationContext->clientSessionTicket = outResult.SessionTicket;\n"
-            + (isInstanceApi ? tabbing + "    std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = this->GetOrCreateAuthenticationContext();\n" : "")
-            + tabbing + "    " + authContext + "clientSessionTicket = outResult.SessionTicket;\n"
-            + tabbing + "    if (outResult.EntityToken.notNull()) {\n"
-            + tabbing + "        outResult.authenticationContext->entityToken = outResult.EntityToken->EntityToken;\n"
-            + tabbing + "        " + authContext + "entityToken = outResult.EntityToken->EntityToken;\n"
-            + tabbing + "    }\n"
-            + tabbing + "    MultiStepClientLogin(outResult.SettingsForUser->NeedsAttribution);\n"
-            + tabbing + "}\n";
-    }
+        return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.Entity->Id, outResult.Entity->Type, outResult.EntityToken);\n";
+    if (apiCall.result === "LoginResult")
+        return tabbing + "outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n" +
+            tabbing + "outResult.authenticationContext->HandlePlayFabLogin(outResult.PlayFabId, outResult.SessionTicket, outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n" +
+            tabbing + "context->HandlePlayFabLogin(outResult.PlayFabId, outResult.SessionTicket, outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n" +
+            tabbing + "MultiStepClientLogin(context, outResult.SettingsForUser->NeedsAttribution);\n";
     if (apiCall.result === "RegisterPlayFabUserResult")
-        return tabbing + "if (outResult.SessionTicket.length() > 0)\n"
-            + tabbing + "{\n"
-            + tabbing + "    " + (isInstanceApi ? "this->GetOrCreateAuthenticationContext()->" : "PlayFabSettings::") + "clientSessionTicket = outResult.SessionTicket;\n"
-            + tabbing + "    MultiStepClientLogin(outResult.SettingsForUser->NeedsAttribution);\n"
-            + tabbing + "}\n";
-    if (apiCall.result === "AttributeInstallResult") {
-        if (isInstanceApi) {
-            return tabbing + "auto apiSettings = this->GetSettings();\n"
-                + tabbing + "if (apiSettings == nullptr)\n"
-                + tabbing + "{\n"
-                + tabbing + "    PlayFabSettings::advertisingIdType += \"_Successful\";\n"
-                + tabbing + "}\n"
-                + tabbing + "else\n"
-                + tabbing + "{\n"
-                + tabbing + "    apiSettings->advertisingIdType += \"_Successful\";\n"
-                + tabbing + "}\n";
-        }
-        else {
-            return tabbing + "PlayFabSettings::advertisingIdType += \"_Successful\";\n";
-        }
-    }
+        return tabbing + "context->HandlePlayFabLogin(outResult.PlayFabId, outResult.SessionTicket, outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n"
+            + tabbing + "MultiStepClientLogin(context, outResult.SettingsForUser->NeedsAttribution);\n";
+    if (apiCall.result === "AttributeInstallResult")
+        return tabbing + "context->advertisingIdType += \"_Successful\";\n";
 
     return "";
 }

--- a/source/code/include/playfab/PlayFabApiSettings.h
+++ b/source/code/include/playfab/PlayFabApiSettings.h
@@ -20,6 +20,12 @@ namespace PlayFab
 #endif
 
         PlayFabApiSettings();
+        PlayFabApiSettings(const PlayFabApiSettings& other) = delete;
+        PlayFabApiSettings(PlayFabApiSettings&& other) = delete;
+        PlayFabApiSettings& operator=(const PlayFabApiSettings& other) = delete;
+        PlayFabApiSettings& operator=(PlayFabApiSettings&& other) = delete;
+        ~PlayFabApiSettings() = default;
+
         std::string GetUrl(const std::string& urlPath) const;
     };
 }

--- a/source/code/include/playfab/PlayFabApiSettings.h
+++ b/source/code/include/playfab/PlayFabApiSettings.h
@@ -11,20 +11,15 @@ namespace PlayFab
     class PlayFabApiSettings
     {
     public:
-#ifndef DISABLE_PLAYFABCLIENT_API
-        std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant (defined in PlayFabSettings)
-        std::string advertisingIdValue; // Set this to corresponding device value
+        static const std::map<std::string, std::string> requestGetParams;
 
-        // DisableAdvertising is provided for completeness, but changing it is not suggested
-        // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
-        bool disableAdvertising;
-#endif
-
-        std::string verticalName; // The name of a PlayFab service vertical
         std::string baseServiceHost; // The base for a PlayFab service host
         std::string titleId; // You must set this value for PlayFabSdk to work properly (found in the Game Manager for your title, at the PlayFab Website)
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+        std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
+#endif
 
         PlayFabApiSettings();
-        std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams) const;
+        std::string GetUrl(const std::string& urlPath) const;
     };
 }

--- a/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -11,16 +11,20 @@ namespace PlayFab
     {
     public:
 #ifndef DISABLE_PLAYFABCLIENT_API
+        // DisableAdvertising is provided for completeness, but changing it is not suggested
+        // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
+        bool disableAdvertising;
+        std::string playFabId; // Master_Player_Entity Id for the Player that logged in
         std::string clientSessionTicket; // Client session ticket that is used as an authentication token in many PlayFab API methods.
+        std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant below
+        std::string advertisingIdValue; // Set this to corresponding device value
 #endif
-#ifndef DISABLE_PLAYFABENTITY_API
+        std::string entityId; // Entity Id for the active entity
+        std::string entityType; // Entity Type for the active entity
         std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.
-#endif
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-        std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
-#endif
 
         PlayFabAuthenticationContext();
+        void HandlePlayFabLogin(const std::string& setPlayFabId, const std::string& setClientSessionTicket, const std::string& setEntityId, const std::string& setEntityType, const std::string& setEntityToken);
         void ForgetAllCredentials();
     };
 }

--- a/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -24,6 +24,12 @@ namespace PlayFab
         std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.
 
         PlayFabAuthenticationContext();
+        PlayFabAuthenticationContext(const PlayFabAuthenticationContext& other) = delete;
+        PlayFabAuthenticationContext(PlayFabAuthenticationContext&& other) = delete;
+        PlayFabAuthenticationContext& operator=(const PlayFabAuthenticationContext& other) = delete;
+        PlayFabAuthenticationContext& operator=(PlayFabAuthenticationContext&& other) = delete;
+        ~PlayFabAuthenticationContext() = default;
+
         void HandlePlayFabLogin(const std::string& setPlayFabId, const std::string& setClientSessionTicket, const std::string& setEntityId, const std::string& setEntityType, const std::string& setEntityToken);
         void ForgetAllCredentials();
     };

--- a/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -30,7 +30,7 @@ namespace PlayFab
         PlayFabAuthenticationContext& operator=(PlayFabAuthenticationContext&& other) = delete;
         ~PlayFabAuthenticationContext() = default;
 
-        void HandlePlayFabLogin(const std::string& setPlayFabId, const std::string& setClientSessionTicket, const std::string& setEntityId, const std::string& setEntityType, const std::string& setEntityToken);
+        void HandlePlayFabLogin(const std::string& _playFabId, const std::string& _clientSessionTicket, const std::string& _entityId, const std::string& _entityType, const std::string& _entityToken);
         void ForgetAllCredentials();
     };
 }

--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -24,7 +24,7 @@ namespace PlayFab
         std::string GetFullUrl() const;
         std::shared_ptr<PlayFabApiSettings> GetApiSettings() const;
         std::shared_ptr<PlayFabAuthenticationContext> GetContext() const;
-        bool ValidateSettings();
+        bool HandleInvalidSettings();
 
         // TODO: clean up these public variables with setters/getters when you have the chance.
 

--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabError.h>
 #include <playfab/PlayFabCallRequestContainerBase.h>
 
@@ -21,7 +22,9 @@ namespace PlayFab
 
         virtual ~CallRequestContainer() override;
         std::string GetFullUrl() const;
-        virtual bool ValidateSettings() override;
+        std::shared_ptr<PlayFabApiSettings> GetApiSettings() const;
+        std::shared_ptr<PlayFabAuthenticationContext> GetContext() const;
+        bool ValidateSettings();
 
         // TODO: clean up these public variables with setters/getters when you have the chance.
 
@@ -31,5 +34,7 @@ namespace PlayFab
         PlayFabError errorWrapper;
         std::shared_ptr<void> successCallback;
         ErrorCallback errorCallback;
+        std::shared_ptr<PlayFabApiSettings> m_settings;
+        std::shared_ptr<PlayFabAuthenticationContext> m_context;
     };
 }

--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -6,7 +6,7 @@
 namespace PlayFab
 {
     /// <summary>
-    /// Internal PlayFabHttp container for each api call
+    /// Internal PlayFabHttp container for each API call
     /// </summary>
     class CallRequestContainer : public CallRequestContainerBase
     {
@@ -15,11 +15,13 @@ namespace PlayFab
             const std::unordered_map<std::string, std::string>& headers,
             const std::string& requestBody,
             CallRequestContainerCallback callback,
-            void* customData = nullptr,
-            std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);
+            std::shared_ptr<PlayFabApiSettings> apiSettings,
+            std::shared_ptr<PlayFabAuthenticationContext> context,
+            void* customData);
 
         virtual ~CallRequestContainer() override;
         std::string GetFullUrl() const;
+        virtual bool ValidateSettings() override;
 
         // TODO: clean up these public variables with setters/getters when you have the chance.
 

--- a/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <playfab/PlayFabApiSettings.h>
 #include <unordered_map>
 #include <memory>
 
@@ -27,9 +26,7 @@ namespace PlayFab
             const std::unordered_map<std::string, std::string>& headers,
             std::string requestBody,
             CallRequestContainerCallback callback,
-            std::shared_ptr<PlayFabApiSettings> apiSettings,
-            std::shared_ptr<PlayFabAuthenticationContext> context,
-            void* customData);
+            void* customData = nullptr);
 
         virtual ~CallRequestContainerBase() = default;
 
@@ -38,8 +35,6 @@ namespace PlayFab
         std::string GetRequestId() const;
         void SetRequestId(const std::string& newRequestId);
         std::string GetRequestBody() const;
-        std::shared_ptr<PlayFabApiSettings> GetApiSettings() const;
-        std::shared_ptr<PlayFabAuthenticationContext> GetContext() const;
 
         /// <summary>
         /// This function is meant to handle logic of calling the error callback or success
@@ -47,15 +42,12 @@ namespace PlayFab
         CallRequestContainerCallback GetCallback() const;
 
         void* GetCustomData() const;
-        virtual bool ValidateSettings() = 0;
 
     protected:
         std::string url;
         std::unordered_map<std::string, std::string> requestHeaders;
         std::string requestBody;
         std::string requestId;
-        std::shared_ptr<PlayFabApiSettings> m_settings;
-        std::shared_ptr<PlayFabAuthenticationContext> m_context;
         CallRequestContainerCallback callback;
 
         // I never own this, I can never destroy it

--- a/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -27,8 +27,9 @@ namespace PlayFab
             const std::unordered_map<std::string, std::string>& headers,
             std::string requestBody,
             CallRequestContainerCallback callback,
-            void* customData = nullptr,
-            std::shared_ptr<PlayFabApiSettings> apiSettings = nullptr);
+            std::shared_ptr<PlayFabApiSettings> apiSettings,
+            std::shared_ptr<PlayFabAuthenticationContext> context,
+            void* customData);
 
         virtual ~CallRequestContainerBase() = default;
 
@@ -38,6 +39,7 @@ namespace PlayFab
         void SetRequestId(const std::string& newRequestId);
         std::string GetRequestBody() const;
         std::shared_ptr<PlayFabApiSettings> GetApiSettings() const;
+        std::shared_ptr<PlayFabAuthenticationContext> GetContext() const;
 
         /// <summary>
         /// This function is meant to handle logic of calling the error callback or success
@@ -45,13 +47,15 @@ namespace PlayFab
         CallRequestContainerCallback GetCallback() const;
 
         void* GetCustomData() const;
+        virtual bool ValidateSettings() = 0;
 
     protected:
         std::string url;
         std::unordered_map<std::string, std::string> requestHeaders;
         std::string requestBody;
         std::string requestId;
-        std::shared_ptr<PlayFabApiSettings> apiSettings;
+        std::shared_ptr<PlayFabApiSettings> m_settings;
+        std::shared_ptr<PlayFabAuthenticationContext> m_context;
         CallRequestContainerCallback callback;
 
         // I never own this, I can never destroy it

--- a/source/code/include/playfab/PlayFabError.h.ejs
+++ b/source/code/include/playfab/PlayFabError.h.ejs
@@ -42,4 +42,29 @@ namespace PlayFab
 
     typedef std::function<void(const PlayFabError& error, void* customData)> ErrorCallback;
     typedef std::function<void(std::exception exception)> ExceptionCallback;
+
+    enum class PlayFabExceptionCode
+    {
+        AuthContextRequired,
+        DeveloperKeyNotSet,
+        EntityTokenNotSet,
+        NotLoggedIn,
+        PluginAmbiguity,
+        PluginNotFound,
+        ThreadMisuse,
+        TitleNotSet,
+    };
+
+    class PlayFabException : public std::runtime_error
+    {
+    public:
+        PlayFabException() = delete;
+        PlayFabException(const PlayFabException& source) = default;
+        PlayFabException(PlayFabException&&) = default;
+        PlayFabException& operator=(const PlayFabException& source) = default;
+        PlayFabException& operator=(PlayFabException&& other) = default;
+
+        PlayFabExceptionCode Code;
+        PlayFabException(PlayFabExceptionCode code, const char* const message);
+    };
 }

--- a/source/code/include/playfab/PlayFabError.h.ejs
+++ b/source/code/include/playfab/PlayFabError.h.ejs
@@ -59,10 +59,10 @@ namespace PlayFab
     {
     public:
         PlayFabException() = delete;
-        PlayFabException(const PlayFabException& source) = default;
+        PlayFabException(const PlayFabException& source) = delete;
         PlayFabException(PlayFabException&&) = default;
-        PlayFabException& operator=(const PlayFabException& source) = default;
-        PlayFabException& operator=(PlayFabException&& other) = default;
+        PlayFabException& operator=(const PlayFabException& source) = delete;
+        PlayFabException& operator=(PlayFabException&& other) = delete;
 
         PlayFabExceptionCode Code;
         PlayFabException(PlayFabExceptionCode code, const char* const message);

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -88,7 +88,8 @@ namespace PlayFab
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
-        std::shared_ptr<PlayFabEventPipelineSettings> settings;
+        std::shared_ptr<PlayFabEventPipelineSettings> m_settings;
+        std::shared_ptr<PlayFabAuthenticationContext> m_context;
         PlayFabEventBuffer buffer;
         std::thread workerThread;
         std::atomic<bool> isWorkerThreadRunning;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -89,7 +89,6 @@ namespace PlayFab
 
     private:
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
-        std::shared_ptr<PlayFabAuthenticationContext> context;
         PlayFabEventBuffer buffer;
         std::thread workerThread;
         std::atomic<bool> isWorkerThreadRunning;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -88,8 +88,8 @@ namespace PlayFab
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
-        std::shared_ptr<PlayFabEventPipelineSettings> m_settings;
-        std::shared_ptr<PlayFabAuthenticationContext> m_context;
+        std::shared_ptr<PlayFabEventPipelineSettings> settings;
+        std::shared_ptr<PlayFabAuthenticationContext> context;
         PlayFabEventBuffer buffer;
         std::thread workerThread;
         std::atomic<bool> isWorkerThreadRunning;

--- a/source/code/include/playfab/PlayFabSettings.h
+++ b/source/code/include/playfab/PlayFabSettings.h
@@ -15,39 +15,22 @@ namespace PlayFab
         static const std::string sdkVersion;
         static const std::string buildIdentifier;
         static const std::string versionString;
-        static const std::string verticalName;
 
-        static const std::map<std::string, std::string> requestGetParams;
-
-        static bool useDevelopmentEnvironment;
-        static std::string developmentEnvironmentURL;
         static std::string productionEnvironmentURL;
-        static std::string titleId; // You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website)
         static ErrorCallback globalErrorHandler;
 
-        // Control whether all callbacks are threaded or whether the user manually controlls callback timing from their main-thread
+        static std::shared_ptr<PlayFabApiSettings> staticSettings;
+        static std::shared_ptr<PlayFabAuthenticationContext> staticPlayer;
+
+        // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
         static bool threadedCallbacks;
 
-        static std::string entityToken; // This is set by entity GetEntityToken method, and is required by all other Entity API methods
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-        static std::string developerSecretKey; // You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website)
-#endif
 #ifndef DISABLE_PLAYFABCLIENT_API
-        static std::string clientSessionTicket; // This is set by any Client Login method, and is required for all other Client API methods
-        static std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant below
-        static std::string advertisingIdValue; // Set this to corresponding device value
-
-        // DisableAdvertising is provided for completeness, but changing it is not suggested
-        // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
-        static bool disableAdvertising;
         static const std::string AD_TYPE_IDFA;
         static const std::string AD_TYPE_ANDROID_ID;
+#endif
 
         static void ForgetAllCredentials();
-
-        static std::string GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams);
-#endif
-        static bool ValidateSettings(const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container);
     private:
         PlayFabSettings(); // Private constructor, static class should never have an instance
         PlayFabSettings(const PlayFabSettings& other); // Private copy-constructor, static class should never have an instance

--- a/source/code/include/playfab/PlayFabSettings.h
+++ b/source/code/include/playfab/PlayFabSettings.h
@@ -16,14 +16,16 @@ namespace PlayFab
         static const std::string buildIdentifier;
         static const std::string versionString;
 
-        static std::string productionEnvironmentURL;
-        static ErrorCallback globalErrorHandler;
-
-        static std::shared_ptr<PlayFabApiSettings> staticSettings;
-        static std::shared_ptr<PlayFabAuthenticationContext> staticPlayer;
-
         // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
         static bool threadedCallbacks;
+        // Used to override the PlayFab endpoint url - Not typical
+        static std::string productionEnvironmentURL;
+        // Used to receive a callback for every failed PlayFab API call - Parallel to the individual error callbacks
+        static ErrorCallback globalErrorHandler;
+
+        // The pointers to these objects should be const as they should always be fixed, but the contents are still mutable
+        static const std::shared_ptr<PlayFabApiSettings> staticSettings;
+        static const std::shared_ptr<PlayFabAuthenticationContext> staticPlayer;
 
 #ifndef DISABLE_PLAYFABCLIENT_API
         static const std::string AD_TYPE_IDFA;

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -605,7 +605,7 @@ namespace PlayFab
 
     std::string PlayFabAndroidHttpPlugin::GetUrl(const RequestTask& requestTask) const
     {
-        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::staticSettings->requestGetParams);
+        return requestTask.GetRequestContainerUrl();
     }
 
     void PlayFabAndroidHttpPlugin::SetPredefinedHeaders(const RequestTask& requestTask)

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -247,6 +247,11 @@ namespace PlayFab
 
     void PlayFabAndroidHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
+        if (!requestContainer->ValidateSettings())
+        {
+            return;
+        }
+
         std::shared_ptr<RequestTask> requestTask = nullptr;
         try
         {
@@ -275,7 +280,7 @@ namespace PlayFab
     {
         if (PlayFabSettings::threadedCallbacks)
         {
-            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+            throw PlayFabException(PlayFabExceptionCode::ThreadMisuse, "You should not call Update() when PlayFabSettings::threadedCallbacks == true");
         }
 
         std::shared_ptr<RequestTask> requestTask = nullptr;
@@ -600,7 +605,7 @@ namespace PlayFab
 
     std::string PlayFabAndroidHttpPlugin::GetUrl(const RequestTask& requestTask) const
     {
-        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::requestGetParams);
+        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::staticSettings->requestGetParams);
     }
 
     void PlayFabAndroidHttpPlugin::SetPredefinedHeaders(const RequestTask& requestTask)

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -248,7 +248,7 @@ namespace PlayFab
     void PlayFabAndroidHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && !container->ValidateSettings())
+        if (container != nullptr && !container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try

--- a/source/code/source/playfab/PlayFabApiSettings.cpp
+++ b/source/code/source/playfab/PlayFabApiSettings.cpp
@@ -5,39 +5,33 @@
 
 namespace PlayFab
 {
+    const std::map<std::string, std::string> PlayFabApiSettings::requestGetParams = {
+        { "sdk", PlayFabSettings::versionString }
+    };
+
     PlayFabApiSettings::PlayFabApiSettings() :
-#ifndef DISABLE_PLAYFABCLIENT_API
-        advertisingIdType(PlayFabSettings::advertisingIdType),
-        advertisingIdValue(PlayFabSettings::advertisingIdValue),
-        disableAdvertising(PlayFabSettings::disableAdvertising),
-#endif
-        verticalName(PlayFabSettings::verticalName),
         baseServiceHost(PlayFabSettings::productionEnvironmentURL),
-        titleId(PlayFabSettings::titleId)
+        titleId()
     {
+        // Don't let PlayFabSettings::staticSettings pull titleId from itself
+        if (PlayFabSettings::staticSettings != nullptr)
+        {
+            titleId = PlayFabSettings::staticSettings->titleId;
+        }
     }
 
-    std::string PlayFabApiSettings::GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams) const
+    std::string PlayFabApiSettings::GetUrl(const std::string& urlPath) const
     {
         std::string fullUrl;
         fullUrl.reserve(1000);
 
         fullUrl += "https://";
-
-        if (verticalName.length() > 0)
-        {
-            fullUrl += verticalName;
-        }
-        else
-        {
-            fullUrl += titleId;
-        }
-
+        fullUrl += titleId;
         fullUrl += baseServiceHost;
         fullUrl += urlPath;
 
         bool firstParam = true;
-        for (auto const& paramPair : getParams)
+        for (auto const& paramPair : requestGetParams)
         {
             if (firstParam) {
                 fullUrl += "?";

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -32,17 +32,17 @@ namespace PlayFab
     }
 
     void PlayFabAuthenticationContext::HandlePlayFabLogin(
-        const std::string& setPlayFabId,
-        const std::string& setClientSessionTicket,
-        const std::string& setEntityId,
-        const std::string& setEntityType,
-        const std::string& setEntityToken
+        const std::string& _playFabId,
+        const std::string& _clientSessionTicket,
+        const std::string& _entityId,
+        const std::string& _entityType,
+        const std::string& _entityToken
     )
     {
-        SetIfNotNull(setPlayFabId, playFabId);
-        SetIfNotNull(setClientSessionTicket, clientSessionTicket);
-        SetIfNotNull(setEntityId, entityId);
-        SetIfNotNull(setEntityType, entityType);
-        SetIfNotNull(setEntityToken, entityToken);
+        SetIfNotNull(_playFabId, playFabId);
+        SetIfNotNull(_clientSessionTicket, clientSessionTicket);
+        SetIfNotNull(_entityId, entityId);
+        SetIfNotNull(_entityType, entityType);
+        SetIfNotNull(_entityToken, entityToken);
     }
 }

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -23,12 +23,26 @@ namespace PlayFab
         entityToken.clear();
     }
 
-    void PlayFabAuthenticationContext::HandlePlayFabLogin(const std::string& setPlayFabId, const std::string& setClientSessionTicket, const std::string& setEntityId, const std::string& setEntityType, const std::string& setEntityToken)
+    void SetIfNotNull(const std::string& input, std::string& output)
     {
-        if (!setPlayFabId.empty()) playFabId = setPlayFabId;
-        if (!setClientSessionTicket.empty()) clientSessionTicket = setClientSessionTicket;
-        if (!setEntityId.empty()) entityId = setEntityId;
-        if (!setEntityType.empty()) entityType = setEntityType;
-        if (!setEntityToken.empty()) entityToken = setEntityToken;
+        if (!input.empty())
+        {
+            output = input;
+        }
+    }
+
+    void PlayFabAuthenticationContext::HandlePlayFabLogin(
+        const std::string& setPlayFabId,
+        const std::string& setClientSessionTicket,
+        const std::string& setEntityId,
+        const std::string& setEntityType,
+        const std::string& setEntityToken
+    )
+    {
+        SetIfNotNull(setPlayFabId, playFabId);
+        SetIfNotNull(setClientSessionTicket, clientSessionTicket);
+        SetIfNotNull(setEntityId, entityId);
+        SetIfNotNull(setEntityType, entityType);
+        SetIfNotNull(setEntityToken, entityToken);
     }
 }

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -7,27 +7,28 @@ namespace PlayFab
 {
     PlayFabAuthenticationContext::PlayFabAuthenticationContext()
     {
-#ifndef DISABLE_PLAYFABCLIENT_API
-        clientSessionTicket = PlayFabSettings::clientSessionTicket;
-#endif
-#ifndef DISABLE_PLAYFABENTITY_API
-        entityToken = PlayFabSettings::entityToken;
-#endif
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-        developerSecretKey = PlayFabSettings::developerSecretKey;
-#endif
+        ForgetAllCredentials();
     }
 
     void PlayFabAuthenticationContext::ForgetAllCredentials()
     {
 #ifndef DISABLE_PLAYFABCLIENT_API
+        playFabId.clear();
         clientSessionTicket.clear();
+        advertisingIdType.clear();
+        advertisingIdValue.clear();
 #endif
-#ifndef DISABLE_PLAYFABENTITY_API
+        entityId.clear();
+        entityType.clear();
         entityToken.clear();
-#endif
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-        developerSecretKey.clear();
-#endif
+    }
+
+    void PlayFabAuthenticationContext::HandlePlayFabLogin(const std::string& setPlayFabId, const std::string& setClientSessionTicket, const std::string& setEntityId, const std::string& setEntityType, const std::string& setEntityToken)
+    {
+        if (!setPlayFabId.empty()) playFabId = setPlayFabId;
+        if (!setClientSessionTicket.empty()) clientSessionTicket = setClientSessionTicket;
+        if (!setEntityId.empty()) entityId = setEntityId;
+        if (!setEntityType.empty()) entityType = setEntityType;
+        if (!setEntityToken.empty()) entityToken = setEntityToken;
     }
 }

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -59,7 +59,7 @@ namespace PlayFab
         return this->m_context;
     }
 
-    bool CallRequestContainer::ValidateSettings()
+    bool CallRequestContainer::HandleInvalidSettings()
     {
         bool isValid = true;
         if (m_settings->titleId.empty())

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -49,7 +49,7 @@ namespace PlayFab
 
     bool CallRequestContainer::ValidateSettings()
     {
-        bool valid = true;
+        bool isValid = true;
         if (m_settings->titleId.empty())
         {
             errorWrapper.HttpCode = 0;
@@ -57,17 +57,21 @@ namespace PlayFab
             errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
             errorWrapper.ErrorName = errorWrapper.HttpStatus;
             errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
-            valid = false;
+            isValid = false;
         }
 
-        if (valid)
-            return true;
+        if (!isValid)
+        {
+            if (PlayFabSettings::globalErrorHandler != nullptr)
+            {
+                PlayFabSettings::globalErrorHandler(errorWrapper, GetCustomData());
+            }
+            if (errorCallback != nullptr)
+            {
+                errorCallback(errorWrapper, GetCustomData());
+            }
+        }
 
-        if (PlayFabSettings::globalErrorHandler != nullptr)
-            PlayFabSettings::globalErrorHandler(errorWrapper, GetCustomData());
-        if (errorCallback != nullptr)
-            errorCallback(errorWrapper, GetCustomData());
-
-        return false;
+        return isValid;
     }
 }

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -12,13 +12,15 @@ namespace PlayFab
         std::shared_ptr<PlayFabApiSettings> settings,
         std::shared_ptr<PlayFabAuthenticationContext> context,
         void* customData) :
-        CallRequestContainerBase(url, headers, requestBody, callback, settings, context, customData),
+        CallRequestContainerBase(url, headers, requestBody, callback, customData),
         finished(false),
         responseString(""),
         responseJson(Json::Value::null),
         errorWrapper(),
         successCallback(nullptr),
-        errorCallback(nullptr)
+        errorCallback(nullptr),
+        m_settings(settings),
+        m_context(context)
     {
         errorWrapper.UrlPath = url;
 
@@ -45,6 +47,16 @@ namespace PlayFab
     std::string CallRequestContainer::GetFullUrl() const
     {
         return m_settings->GetUrl(this->GetUrl());
+    }
+
+    std::shared_ptr<PlayFabApiSettings> CallRequestContainer::GetApiSettings() const
+    {
+        return this->m_settings;
+    }
+
+    std::shared_ptr<PlayFabAuthenticationContext> CallRequestContainer::GetContext() const
+    {
+        return this->m_context;
     }
 
     bool CallRequestContainer::ValidateSettings()

--- a/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -9,12 +9,14 @@ namespace PlayFab
         const std::unordered_map<std::string, std::string>& headers,
         std::string requestBody,
         CallRequestContainerCallback callback,
-        void* customData,
-        std::shared_ptr<PlayFabApiSettings> settings) :
+        std::shared_ptr<PlayFabApiSettings> settings,
+        std::shared_ptr<PlayFabAuthenticationContext> context,
+        void* customData) :
         url(url),
         requestHeaders(headers),
         requestBody(requestBody),
-        apiSettings(settings),
+        m_settings(settings),
+        m_context(context),
         callback(callback),
         customData(customData)
     {
@@ -47,7 +49,12 @@ namespace PlayFab
 
     std::shared_ptr<PlayFabApiSettings> CallRequestContainerBase::GetApiSettings() const
     {
-        return this->apiSettings;
+        return this->m_settings;
+    }
+
+    std::shared_ptr<PlayFabAuthenticationContext> CallRequestContainerBase::GetContext() const
+    {
+        return this->m_context;
     }
 
     CallRequestContainerCallback CallRequestContainerBase::GetCallback() const

--- a/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainerBase.cpp
@@ -9,14 +9,10 @@ namespace PlayFab
         const std::unordered_map<std::string, std::string>& headers,
         std::string requestBody,
         CallRequestContainerCallback callback,
-        std::shared_ptr<PlayFabApiSettings> settings,
-        std::shared_ptr<PlayFabAuthenticationContext> context,
         void* customData) :
         url(url),
         requestHeaders(headers),
         requestBody(requestBody),
-        m_settings(settings),
-        m_context(context),
         callback(callback),
         customData(customData)
     {
@@ -45,16 +41,6 @@ namespace PlayFab
     std::string CallRequestContainerBase::GetRequestBody() const
     {
         return this->requestBody;
-    }
-
-    std::shared_ptr<PlayFabApiSettings> CallRequestContainerBase::GetApiSettings() const
-    {
-        return this->m_settings;
-    }
-
-    std::shared_ptr<PlayFabAuthenticationContext> CallRequestContainerBase::GetContext() const
-    {
-        return this->m_context;
     }
 
     CallRequestContainerCallback CallRequestContainerBase::GetCallback() const

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -110,11 +110,8 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
-        if (!requestContainer->ValidateSettings())
-        {
-            return;
-        }
-
+        CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+        if (container != nullptr && !container->ValidateSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -110,6 +110,11 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
+        if (!requestContainer->ValidateSettings())
+        {
+            return;
+        }
+
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
@@ -265,7 +270,7 @@ namespace PlayFab
     {
         if (PlayFabSettings::threadedCallbacks)
         {
-            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+            throw PlayFabException(PlayFabExceptionCode::ThreadMisuse, "You should not call Update() when PlayFabSettings::threadedCallbacks == true");
         }
 
         std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -111,7 +111,7 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && !container->ValidateSettings())
+        if (container != nullptr && !container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabError.cpp
+++ b/source/code/source/playfab/PlayFabError.cpp
@@ -60,4 +60,9 @@ namespace PlayFab
         }
         return output;
     }
+
+    PlayFabException::PlayFabException(PlayFabExceptionCode code, const char* const message) : std::runtime_error(message)
+    {
+        this->Code = code;
+    }
 }

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -40,9 +40,9 @@ namespace PlayFab
         buffer(settings->bufferSize),
         isWorkerThreadRunning(false)
     {
-        this->m_settings = std::move(settings);
-        this->batch.reserve(this->m_settings->maximalNumberOfItemsInBatch);
-        this->batchesInFlight.reserve(this->m_settings->maximalNumberOfBatchesInFlight);
+        this->settings = std::move(settings);
+        this->batch.reserve(this->settings->maximalNumberOfItemsInBatch);
+        this->batchesInFlight.reserve(this->settings->maximalNumberOfBatchesInFlight);
         this->Start();
     }
 
@@ -68,7 +68,7 @@ namespace PlayFab
 
     std::shared_ptr<PlayFabEventPipelineSettings> PlayFabEventPipeline::GetSettings() const
     {
-        return this->m_settings;
+        return this->settings;
     }
 
     void PlayFabEventPipeline::IntakeEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request)
@@ -140,11 +140,11 @@ namespace PlayFab
             try
             {
                 // Process events in the loop
-                if (this->batchesInFlight.size() >= this->m_settings->maximalNumberOfBatchesInFlight)
+                if (this->batchesInFlight.size() >= this->settings->maximalNumberOfBatchesInFlight)
                 {
                     // do not take new events from buffer if batches currently in flight are at the maximum allowed number
                     // and are not sent out (or received an error) yet
-                    std::this_thread::sleep_for(std::chrono::milliseconds(this->m_settings->readBufferWaitTime)); // give some time for batches in flight to deflate
+                    std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime)); // give some time for batches in flight to deflate
                     continue;
                 }
 
@@ -156,7 +156,7 @@ namespace PlayFab
                         this->batch.push_back(std::move(request));
 
                         // if batch is full
-                        if (this->batch.size() >= this->m_settings->maximalNumberOfItemsInBatch)
+                        if (this->batch.size() >= this->settings->maximalNumberOfItemsInBatch)
                         {
                             this->SendBatch(batchCounter);
                         }
@@ -181,7 +181,7 @@ namespace PlayFab
                 {
                     // check if the batch wait time expired
                     std::chrono::seconds batchAge = std::chrono::duration_cast<std::chrono::seconds>(clock::now() - momentBatchStarted);
-                    if (batchAge.count() >= (int32_t)this->m_settings->maximalBatchWaitTime)
+                    if (batchAge.count() >= (int32_t)this->settings->maximalBatchWaitTime)
                     {
                         // batch wait time expired, send incomplete batch
                         this->SendBatch(batchCounter);
@@ -191,7 +191,7 @@ namespace PlayFab
 
                 // event buffer is disabled or empty, and batch is not ready to be sent yet
                 // give some time back to CPU, don't starve it without a good reason
-                std::this_thread::sleep_for(std::chrono::milliseconds(this->m_settings->readBufferWaitTime));
+                std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime));
             }
             catch (const std::exception& ex)
             {
@@ -217,9 +217,9 @@ namespace PlayFab
     {
         // create a WriteEvents API request to send the batch
         EventsModels::WriteEventsRequest batchReq;
-        if (this->m_settings->authenticationContext != nullptr)
+        if (this->settings->authenticationContext != nullptr)
         {
-            batchReq.authenticationContext = this->m_settings->authenticationContext;
+            batchReq.authenticationContext = this->settings->authenticationContext;
         }
 
         for (const auto& eventEmitRequest : this->batch)
@@ -234,8 +234,8 @@ namespace PlayFab
         batchCounter++;
 
         this->batch.clear(); // batch vector will be reused
-        this->batch.reserve(this->m_settings->maximalNumberOfItemsInBatch);
-        if(this->m_settings->emitType == PlayFabEventPipelineType::PlayFabPlayStream)
+        this->batch.reserve(this->settings->maximalNumberOfItemsInBatch);
+        if(this->settings->emitType == PlayFabEventPipelineType::PlayFabPlayStream)
         {
             // call Events API to send the batch
             PlayFabEventsAPI::WriteEvents(

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -91,6 +91,11 @@ namespace PlayFab
 
     void PlayFabIOSHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
+        if (!requestContainer->ValidateSettings())
+        {
+            return;
+        }
+
         std::shared_ptr<RequestTask> requestTask = nullptr;
         try
         {
@@ -122,7 +127,7 @@ namespace PlayFab
     {
         if (PlayFabSettings::threadedCallbacks)
         {
-            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+            throw PlayFabException(PlayFabExceptionCode::ThreadMisuse, "You should not call Update() when PlayFabSettings::threadedCallbacks == true");
         }
 
         std::shared_ptr<RequestTask> requestTask = nullptr;
@@ -273,7 +278,7 @@ namespace PlayFab
 
     std::string PlayFabIOSHttpPlugin::GetUrl(const RequestTask& requestTask) const
     {
-        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::requestGetParams);
+        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::staticSettings->requestGetParams);
     }
 
     void PlayFabIOSHttpPlugin::SetPredefinedHeaders(const RequestTask& requestTask, void* urlRequest)

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -278,7 +278,7 @@ namespace PlayFab
 
     std::string PlayFabIOSHttpPlugin::GetUrl(const RequestTask& requestTask) const
     {
-        return PlayFabSettings::GetUrl(requestTask.GetRequestContainerUrl(), PlayFabSettings::staticSettings->requestGetParams);
+        return requestTask.GetRequestContainerUrl();
     }
 
     void PlayFabIOSHttpPlugin::SetPredefinedHeaders(const RequestTask& requestTask, void* urlRequest)

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -106,8 +106,8 @@ namespace PlayFab
             }
             catch (...)
             {
-
             }
+
             if(requestTask != nullptr)
             { // LOCK httpRequestMutex
                 std::unique_lock<std::mutex> lock(httpRequestMutex);

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -92,7 +92,7 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->ValidateSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -113,6 +113,7 @@ namespace PlayFab
                 std::unique_lock<std::mutex> lock(httpRequestMutex);
                 requestTask->state = RequestTask::State::Pending;
                 pendingRequests.push_back(std::move(requestTask));
+
                 if(workerThread == nullptr)
                 {
                     threadRunning = true;

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -94,11 +94,8 @@ namespace PlayFab
 
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
-        if (!requestContainer->ValidateSettings())
-        {
-            return;
-        }
-
+        CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+        if (container != nullptr && container->ValidateSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -95,7 +95,7 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->ValidateSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -94,6 +94,11 @@ namespace PlayFab
 
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
+        if (!requestContainer->ValidateSettings())
+        {
+            return;
+        }
+
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
@@ -247,7 +252,7 @@ namespace PlayFab
     {
         if (PlayFabSettings::threadedCallbacks)
         {
-            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+            throw PlayFabException(PlayFabExceptionCode::ThreadMisuse, "You should not call Update() when PlayFabSettings::threadedCallbacks == true");
         }
 
         std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;

--- a/source/code/source/playfab/PlayFabPluginManager.cpp
+++ b/source/code/source/playfab/PlayFabPluginManager.cpp
@@ -42,7 +42,7 @@ namespace PlayFab
                 pluginPtr = CreatePlayFabTransportPlugin();
                 break;
             default:
-                throw std::runtime_error("This contract is not supported");
+                throw PlayFabException(PlayFabExceptionCode::PluginAmbiguity, "This contract is not supported");
                 break;
             }
 

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -12,8 +12,8 @@ namespace PlayFab
     std::string PlayFabSettings::productionEnvironmentURL = ".playfabapi.com";
     ErrorCallback PlayFabSettings::globalErrorHandler = nullptr;
 
-    std::shared_ptr<PlayFabApiSettings> PlayFabSettings::staticSettings = std::make_shared<PlayFabApiSettings>();
-    std::shared_ptr<PlayFabAuthenticationContext> PlayFabSettings::staticPlayer = std::make_shared<PlayFabAuthenticationContext>();
+    const std::shared_ptr<PlayFabApiSettings> PlayFabSettings::staticSettings = std::make_shared<PlayFabApiSettings>();
+    const std::shared_ptr<PlayFabAuthenticationContext> PlayFabSettings::staticPlayer = std::make_shared<PlayFabAuthenticationContext>();
 
 #ifndef DISABLE_PLAYFABCLIENT_API
     const std::string PlayFabSettings::AD_TYPE_IDFA = "Idfa";

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -4,102 +4,24 @@
 
 namespace PlayFab
 {
+    // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
+    bool PlayFabSettings::threadedCallbacks = false;
     const std::string PlayFabSettings::sdkVersion = "<%- sdkVersion %>";
     const std::string PlayFabSettings::buildIdentifier = "<%- buildIdentifier %>";
     const std::string PlayFabSettings::versionString = "XPlatCppSdk-<%- sdkVersion %>";
-    const std::string PlayFabSettings::verticalName = "<%- getVerticalNameDefault() %>";
-
-    const std::map<std::string, std::string> PlayFabSettings::requestGetParams = {
-        { "sdk", PlayFabSettings::versionString }
-    };
-
-    bool PlayFabSettings::useDevelopmentEnvironment = false;
-    std::string PlayFabSettings::developmentEnvironmentURL = ".playfabsandbox.com";
     std::string PlayFabSettings::productionEnvironmentURL = ".playfabapi.com";
-    std::string PlayFabSettings::titleId; // You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website)
     ErrorCallback PlayFabSettings::globalErrorHandler = nullptr;
 
-    // Control whether all callbacks are threaded or whether the user manually controlls callback timing from their main-thread
-    bool PlayFabSettings::threadedCallbacks = false;
-
-    std::string PlayFabSettings::entityToken; // This is set by entity GetEntityToken method, and is required by all other Entity API methods
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-    std::string PlayFabSettings::developerSecretKey; // You must set this value for PlayFabSdk to work properly (Found in the Game Manager for your title, at the PlayFab Website)
-#endif
+    std::shared_ptr<PlayFabApiSettings> PlayFabSettings::staticSettings = std::make_shared<PlayFabApiSettings>();
+    std::shared_ptr<PlayFabAuthenticationContext> PlayFabSettings::staticPlayer = std::make_shared<PlayFabAuthenticationContext>();
 
 #ifndef DISABLE_PLAYFABCLIENT_API
-    std::string PlayFabSettings::clientSessionTicket; // This is set by any Client Login method, and is required for all other Client API methods
-    std::string PlayFabSettings::advertisingIdType = ""; // Set this to the appropriate AD_TYPE_X constant below
-    std::string PlayFabSettings::advertisingIdValue = ""; // Set this to corresponding device value
-
-    bool PlayFabSettings::disableAdvertising = false;
     const std::string PlayFabSettings::AD_TYPE_IDFA = "Idfa";
     const std::string PlayFabSettings::AD_TYPE_ANDROID_ID = "Adid";
 #endif
 
     void PlayFabSettings::ForgetAllCredentials()
     {
-        entityToken.clear();
-        clientSessionTicket.clear();
-    }
-
-    std::string PlayFabSettings::GetUrl(const std::string& urlPath, const std::map<std::string, std::string>& getParams)
-    {
-        std::string fullUrl;
-        fullUrl.reserve(1000);
-
-        fullUrl += "https://";
-
-        if(PlayFabSettings::verticalName.length() > 0)
-        {
-            fullUrl += PlayFabSettings::verticalName;
-        }
-        else
-        {
-            fullUrl += titleId;
-        }
-
-        fullUrl += useDevelopmentEnvironment ? developmentEnvironmentURL : productionEnvironmentURL;
-        fullUrl += urlPath;
-
-        bool firstParam = true;
-        for (auto const& paramPair : getParams)
-        {
-            if (firstParam) {
-                fullUrl += "?";
-                firstParam = false;
-            } else {
-                fullUrl += "&";
-            }
-            fullUrl += paramPair.first;
-            fullUrl += "=";
-            fullUrl += paramPair.second;
-        }
-        
-        return fullUrl;
-    }
-
-    bool PlayFabSettings::ValidateSettings(const std::shared_ptr<PlayFabAuthenticationContext> authenticationContext, const std::shared_ptr<PlayFabApiSettings> apiSettings, CallRequestContainer& container)
-    {
-        bool valid = true;
-        if (PlayFabSettings::titleId.empty())
-        {
-            container.errorWrapper.HttpCode = 0;
-            container.errorWrapper.HttpStatus = "Client-side validation failure";
-            container.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
-            container.errorWrapper.ErrorName = container.errorWrapper.HttpStatus;
-            container.errorWrapper.ErrorMessage = "PlayFabSettings::titleId has not been set properly. It must not be empty.";
-            valid = false;
-        }
-
-        if (valid)
-            return true;
-
-        if (PlayFabSettings::globalErrorHandler != nullptr)
-            PlayFabSettings::globalErrorHandler(container.errorWrapper, container.GetCustomData());
-        if (container.errorCallback != nullptr)
-            container.errorCallback(container.errorWrapper, container.GetCustomData());
-
-        return false;
+        staticPlayer->ForgetAllCredentials();
     }
 }

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -99,11 +99,8 @@ namespace PlayFab
 
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
-        if (!requestContainer->ValidateSettings())
-        {
-            return;
-        }
-
+        CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
+        if (container != nullptr && container->ValidateSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -99,6 +99,11 @@ namespace PlayFab
 
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
+        if (!requestContainer->ValidateSettings())
+        {
+            return;
+        }
+
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
@@ -429,7 +434,7 @@ namespace PlayFab
     {
         if (PlayFabSettings::threadedCallbacks)
         {
-            throw std::runtime_error("You should not call Update() when PlayFabSettings::threadedCallbacks == true");
+            throw PlayFabException(PlayFabExceptionCode::ThreadMisuse, "You should not call Update() when PlayFabSettings::threadedCallbacks == true");
         }
 
         std::unique_ptr<CallRequestContainerBase> requestContainer = nullptr;

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -100,7 +100,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->ValidateSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -57,33 +57,6 @@ namespace PlayFab
             }
         }
 
-        void WriteTelemetryEvents(
-            WriteEventsRequest& request,
-            const ProcessApiCallback<WriteEventsResponse> callback,
-            const ErrorCallback errorCallback = nullptr,
-            void* customData = nullptr
-        )
-        {
-            IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
-            Json::Value requestJson = request.ToJson();
-            std::string jsonAsString = requestJson.toStyledString();
-
-            std::unordered_map<std::string, std::string> headers;
-            headers.emplace("X-EntityToken", request.authenticationContext == nullptr ? PlayFabSettings::entityToken : request.authenticationContext->entityToken);
-
-            auto reqContainer = std::unique_ptr<CallRequestContainer>(new CallRequestContainer(
-                "/Event/WriteTelemetryEvents",
-                headers,
-                jsonAsString,
-                OnWriteEventsResult,
-                customData));
-
-            reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<WriteEventsResponse>(callback));
-            reqContainer->errorCallback = errorCallback;
-
-            http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
-        }
-
         std::future<QoSResult> PlayFabQoSApi::GetQoSResultAsync(unsigned int numThreads, unsigned int timeoutMs)
         {
             return async(launch::async, [&, numThreads, timeoutMs]() { return GetQoSResult(numThreads, timeoutMs); });
@@ -198,7 +171,7 @@ namespace PlayFab
             eventContents.Payload = value;
             request.Events.push_back(eventContents);
 
-            WriteTelemetryEvents(request, WriteEventsSuccessCallBack, WriteEventsFailureCallBack);
+            PlayFabEventsAPI::WriteTelemetryEvents(request, WriteEventsSuccessCallBack, WriteEventsFailureCallBack);
         }
 
         void PlayFabQoSApi::WriteEventsSuccessCallBack(const WriteEventsResponse&, void*)

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -26,11 +26,11 @@ namespace PlayFabUnit
 
     void PlayFabApiTest::SetTitleInfo(TestTitleData& testInputs)
     {
-        PlayFabSettings::titleId = testInputs.titleId;
+        PlayFabSettings::staticSettings->titleId = testInputs.titleId;
         USER_EMAIL = testInputs.userEmail;
 
         // Verify all the inputs won't cause crashes in the tests
-        TITLE_INFO_SET = !PlayFabSettings::titleId.empty() && !USER_EMAIL.empty();
+        TITLE_INFO_SET = !PlayFabSettings::staticSettings->titleId.empty() && !USER_EMAIL.empty();
     }
 
     void PlayFabApiTest::OnErrorSharedCallback(const PlayFabError& error, void* customData)
@@ -48,30 +48,30 @@ namespace PlayFabUnit
         request.CreateAccount = true;
 
         // store current (valid) title id
-        const std::string validTitleId = PlayFabSettings::titleId;
+        const std::string validTitleId = PlayFabSettings::staticSettings->titleId;
 
         // set invalid title id
-        PlayFabSettings::titleId = "";
+        PlayFabSettings::staticSettings->titleId = "";
 
         PlayFabClientAPI::LoginWithCustomID(request,
             [&validTitleId](const LoginResult&, void* customData)
-            {
-                PlayFabSettings::titleId = validTitleId;
-                TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-                testContext->Fail("Expected API call to fail on the client side");
-            },
+        {
+            PlayFabSettings::staticSettings->titleId = validTitleId;
+            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            testContext->Fail("Expected API call to fail on the client side");
+        },
             [&validTitleId](const PlayFabError& error, void* customData)
-            {
-                PlayFabSettings::titleId = validTitleId;
-                TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-                if (error.HttpCode == 0
-                    && error.HttpStatus == "Client-side validation failure"
-                    && error.ErrorCode == PlayFabErrorCode::PlayFabErrorInvalidParams
-                    && error.ErrorName == error.HttpStatus)
-                    testContext->Pass();
-                else
-                    testContext->Fail("Returned error is different from expected");
-            },
+        {
+            PlayFabSettings::staticSettings->titleId = validTitleId;
+            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            if (error.HttpCode == 0
+                && error.HttpStatus == "Client-side validation failure"
+                && error.ErrorCode == PlayFabErrorCode::PlayFabErrorInvalidParams
+                && error.ErrorName == error.HttpStatus)
+                testContext->Pass();
+            else
+                testContext->Fail("Returned error is different from expected");
+        },
             &testContext);
     }
 
@@ -104,14 +104,14 @@ namespace PlayFabUnit
         }
         else
 #endif // defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        if (error.ErrorMessage.find("password") != -1)
-        {
-            testContext->Pass(error.RequestId);
-        }
-        else
-        {
-            testContext->Fail("Password error message not found: " + error.ErrorMessage);
-        }
+            if (error.ErrorMessage.find("password") != -1)
+            {
+                testContext->Pass(error.RequestId);
+            }
+            else
+            {
+                testContext->Fail("Password error message not found: " + error.ErrorMessage);
+            }
     }
 
     /// CLIENT API
@@ -189,8 +189,8 @@ namespace PlayFabUnit
     /// Test that the login call sequence sends the AdvertisingId when set
     void PlayFabApiTest::LoginWithAdvertisingId(TestContext& testContext)
     {
-        PlayFabSettings::advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
-        PlayFabSettings::advertisingIdValue = "PlayFabTestId";
+        PlayFabSettings::staticPlayer->advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
+        PlayFabSettings::staticPlayer->advertisingIdValue = "PlayFabTestId";
 
         LoginWithCustomIDRequest request;
         request.CustomId = PlayFabSettings::buildIdentifier;
@@ -203,7 +203,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnLoginWithAdvertisingId(const LoginResult&, void* customData)
     {
-        // TODO: Need to wait for the NEXT api call to complete, and then test PlayFabSettings::advertisingIdType
+        // TODO: Need to wait for the NEXT api call to complete, and then test PlayFabSettings::staticPlayer->advertisingIdType
         TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Pass();
     }

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
@@ -112,7 +112,9 @@ namespace PlayFabUnit
     {
         // Wait for both threads to stop
         if (!thread1Complete || !thread2Complete)
+        {
             return;
+        }
 
         // Once retrieved, each user should have a unique ID.
         if (!multiUser1Error.empty() || !multiUser2Error.empty())
@@ -125,9 +127,13 @@ namespace PlayFabUnit
         std::string multiUser2PlayFabId = multiUser2ClientApi->GetAuthenticationContext()->playFabId;
 
         if (multiUser1PlayFabId == multiUser2PlayFabId)
+        {
             testContext.Fail("User 1 PlayFabId (" + multiUser1PlayFabId + ") should not match User 2 PlayFabId (" + multiUser2PlayFabId + ")");
+        }
         else
+        {
             testContext.Pass();
+        }
     }
 
     void PlayFabTestMultiUserInstance::TearDown(TestContext& /*testContext*/)

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
@@ -23,21 +23,21 @@ namespace PlayFabUnit
 
         const auto& user1ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user1ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
-        (*multiUser1ClientApi)->GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
+        multiUser1ClientApi->GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
     }
-    void PlayFabTestMultiUserInstance::MultiUserLogin1Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserInstance::MultiUserLogin1Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to log in user 1: " + error.GenerateErrorReport());
+        multiUser1Error = "Failed to log in user 1: " + error.GenerateErrorReport();
+        thread1Complete = true;
     }
-    void PlayFabTestMultiUserInstance::MultiUserProfile1Success(const GetPlayerProfileResult& result, void* /*customData*/)
+    void PlayFabTestMultiUserInstance::MultiUserProfile1Success(const GetPlayerProfileResult& /*result*/, void* /*customData*/)
     {
-        multiUser1PlayFabId = result.PlayerProfile->PlayerId;
+        thread1Complete = true;
     }
-    void PlayFabTestMultiUserInstance::MultiUserProfile1Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserInstance::MultiUserProfile1Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to get user 1 profile: " + error.GenerateErrorReport());
+        multiUser1Error = "Failed to get user 1 profile: " + error.GenerateErrorReport();
+        thread1Complete = true;
     }
 
     void PlayFabTestMultiUserInstance::MultiUserLogin2Success(const LoginResult& result, void* customData)
@@ -47,21 +47,21 @@ namespace PlayFabUnit
 
         const auto& user2ProfileSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user2ProfileFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
-        (*multiUser2ClientApi)->GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
+        multiUser2ClientApi->GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
     }
-    void PlayFabTestMultiUserInstance::MultiUserLogin2Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserInstance::MultiUserLogin2Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to log in user 2: " + error.GenerateErrorReport());
+        multiUser2Error = "Failed to log in user 2: " + error.GenerateErrorReport();
+        thread2Complete = true;
     }
-    void PlayFabTestMultiUserInstance::MultiUserProfile2Success(const GetPlayerProfileResult& result, void* /*customData*/)
+    void PlayFabTestMultiUserInstance::MultiUserProfile2Success(const GetPlayerProfileResult& /*result*/, void* /*customData*/)
     {
-        multiUser2PlayFabId = result.PlayerProfile->PlayerId;
+        thread2Complete = true;
     }
-    void PlayFabTestMultiUserInstance::MultiUserProfile2Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserInstance::MultiUserProfile2Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to get user 2 profile: " + error.GenerateErrorReport());
+        multiUser2Error = "Failed to get user 2 profile: " + error.GenerateErrorReport();
+        thread2Complete = true;
     }
 
     void PlayFabTestMultiUserInstance::MultiUserLogin(TestContext& testContext)
@@ -73,7 +73,7 @@ namespace PlayFabUnit
 
         const auto& user1LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user1LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
-        (*multiUser1ClientApi)->LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
+        multiUser1ClientApi->LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
 
         LoginWithCustomIDRequest user2LoginRequest;
         user2LoginRequest.CustomId = "test_MultiInstance2";
@@ -81,7 +81,7 @@ namespace PlayFabUnit
 
         const auto& user2LoginSuccess = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user2LoginFailure = std::bind(&PlayFabTestMultiUserInstance::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
-        (*multiUser2ClientApi)->LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
+        multiUser2ClientApi->LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
     }
 
     void PlayFabTestMultiUserInstance::AddTests()
@@ -91,36 +91,55 @@ namespace PlayFabUnit
 
     void PlayFabTestMultiUserInstance::ClassSetUp()
     {
+        // Create API handles for all users.
+        multiUser1ClientApi = std::make_shared<PlayFabClientInstanceAPI>();
+        multiUser2ClientApi = std::make_shared<PlayFabClientInstanceAPI>(std::make_shared<PlayFab::PlayFabApiSettings>()); // also test explicit API settings
+    }
+
+    void PlayFabTestMultiUserInstance::SetUp(TestContext& /*testContext*/)
+    {
         // Make sure PlayFab state is clean.
         PlayFabSettings::ForgetAllCredentials();
 
-        // Create API handles for all users.
-        multiUser1ClientApi = std::make_shared<PlayFabClientInstanceAPI*>(new PlayFabClientInstanceAPI());
-        multiUser2ClientApi = std::make_shared<PlayFabClientInstanceAPI*>(new PlayFabClientInstanceAPI(std::make_shared<PlayFab::PlayFabApiSettings>())); // also test explicit API settings
-
         // Reset state variables.
-        multiUser1PlayFabId = "";
-        multiUser2PlayFabId = "";
+        multiUser1Error.clear();
+        multiUser2Error.clear();
+        thread1Complete = false;
+        thread2Complete = false;
     }
 
     void PlayFabTestMultiUserInstance::Tick(TestContext& testContext)
     {
-        // Wait for both users to become logged in.
-        if (multiUser1PlayFabId.empty() || multiUser2PlayFabId.empty())
+        // Wait for both threads to stop
+        if (!thread1Complete || !thread2Complete)
             return;
 
-        // Once retreived, each user should have a unique ID.
+        // Once retrieved, each user should have a unique ID.
+        if (!multiUser1Error.empty() || !multiUser2Error.empty())
+        {
+            testContext.Fail(multiUser1Error + multiUser2Error);
+            return;
+        }
+
+        std::string multiUser1PlayFabId = multiUser1ClientApi->GetAuthenticationContext()->playFabId;
+        std::string multiUser2PlayFabId = multiUser2ClientApi->GetAuthenticationContext()->playFabId;
+
         if (multiUser1PlayFabId == multiUser2PlayFabId)
             testContext.Fail("User 1 PlayFabId (" + multiUser1PlayFabId + ") should not match User 2 PlayFabId (" + multiUser2PlayFabId + ")");
         else
             testContext.Pass();
     }
 
-    void PlayFabTestMultiUserInstance::ClassTearDown()
+    void PlayFabTestMultiUserInstance::TearDown(TestContext& /*testContext*/)
     {
         // Clean up PlayFab state for next TestCase.
         PlayFabSettings::ForgetAllCredentials();
+        multiUser1ClientApi->ForgetAllCredentials();
+        multiUser2ClientApi->ForgetAllCredentials();
+    }
 
+    void PlayFabTestMultiUserInstance::ClassTearDown()
+    {
         // Release API handles for all users.
         multiUser1ClientApi = nullptr;
         multiUser2ClientApi = nullptr;

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.h
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.h
@@ -20,32 +20,34 @@ namespace PlayFabUnit
 {
     class PlayFabTestMultiUserInstance : public TestCase
     {
-        private:
-            /// <summary>
-            /// CLIENT API
-            /// Try to log in two users simultaneously using instance APIs.
-            /// </summary>
-            std::shared_ptr<PlayFab::PlayFabClientInstanceAPI*> multiUser1ClientApi;
-            std::string multiUser1PlayFabId;
-            std::shared_ptr<PlayFab::PlayFabClientInstanceAPI*> multiUser2ClientApi;
-            std::string multiUser2PlayFabId;
+    private:
+        /// <summary>
+        /// CLIENT API
+        /// Try to log in two users simultaneously using instance APIs.
+        /// </summary>
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> multiUser1ClientApi;
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> multiUser2ClientApi;
+        std::string multiUser1Error, multiUser2Error;
+        bool thread1Complete, thread2Complete;
 
-            void MultiUserLogin1Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
-            void MultiUserLogin1Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserProfile1Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
-            void MultiUserProfile1Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserLogin2Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
-            void MultiUserLogin2Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserProfile2Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
-            void MultiUserProfile2Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserLogin(TestContext& testContext);
+        void MultiUserLogin1Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        void MultiUserLogin1Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserProfile1Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
+        void MultiUserProfile1Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserLogin2Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        void MultiUserLogin2Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserProfile2Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
+        void MultiUserProfile2Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserLogin(TestContext& testContext);
 
-        protected:
-            void AddTests() override;
+    protected:
+        void AddTests() override;
 
-        public:
-            void ClassSetUp() override;
-            void Tick(TestContext& /*testContext*/) override;
-            void ClassTearDown() override;
+    public:
+        void ClassSetUp() override;
+        void SetUp(TestContext& testContext) override;
+        void Tick(TestContext& testContext) override;
+        void TearDown(TestContext& testContext) override;
+        void ClassTearDown() override;
     };
 }

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
@@ -112,7 +112,9 @@ namespace PlayFabUnit
     {
         // Wait for both threads to stop
         if (!thread1Complete || !thread2Complete)
+        {
             return;
+        }
 
         // Once retrieved, each user should have a unique ID.
         if (!multiUser1Error.empty() || !multiUser2Error.empty())
@@ -125,9 +127,13 @@ namespace PlayFabUnit
         std::string multiUser2PlayFabId = multiUser2Context->playFabId;
 
         if (multiUser1PlayFabId == multiUser2PlayFabId)
+        {
             testContext.Fail("User 1 PlayFabId (" + multiUser1PlayFabId + ") should not match User 2 PlayFabId (" + multiUser2PlayFabId + ")");
+        }
         else
+        {
             testContext.Pass();
+        }
     }
 
     void PlayFabTestMultiUserStatic::TearDown(TestContext& /*testContext*/)

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
@@ -24,19 +24,19 @@ namespace PlayFabUnit
         const auto& user1ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
     }
-    void PlayFabTestMultiUserStatic::MultiUserLogin1Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserStatic::MultiUserLogin1Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to log in user 1: " + error.GenerateErrorReport());
+        multiUser1Error = "Failed to log in user 1: " + error.GenerateErrorReport();
+        thread1Complete = true;
     }
-    void PlayFabTestMultiUserStatic::MultiUserProfile1Success(const GetPlayerProfileResult& result, void* /*customData*/)
+    void PlayFabTestMultiUserStatic::MultiUserProfile1Success(const GetPlayerProfileResult& /*result*/, void* /*customData*/)
     {
-        multiUser1PlayFabId = result.PlayerProfile->PlayerId;
+        thread1Complete = true;
     }
-    void PlayFabTestMultiUserStatic::MultiUserProfile1Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserStatic::MultiUserProfile1Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to get user 1 profile: " + error.GenerateErrorReport());
+        multiUser1Error = "Failed to get user 1 profile: " + error.GenerateErrorReport();
+        thread1Complete = true;
     }
 
     void PlayFabTestMultiUserStatic::MultiUserLogin2Success(const LoginResult& result, void* customData)
@@ -48,19 +48,19 @@ namespace PlayFabUnit
         const auto& user2ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
         PlayFabClientAPI::GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
     }
-    void PlayFabTestMultiUserStatic::MultiUserLogin2Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserStatic::MultiUserLogin2Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to log in user 2: " + error.GenerateErrorReport());
+        multiUser2Error = "Failed to log in user 2: " + error.GenerateErrorReport();
+        thread2Complete = true;
     }
-    void PlayFabTestMultiUserStatic::MultiUserProfile2Success(const GetPlayerProfileResult& result, void* /*customData*/)
+    void PlayFabTestMultiUserStatic::MultiUserProfile2Success(const GetPlayerProfileResult& /*result*/, void* /*customData*/)
     {
-        multiUser2PlayFabId = result.PlayerProfile->PlayerId;
+        thread2Complete = true;
     }
-    void PlayFabTestMultiUserStatic::MultiUserProfile2Failure(const PlayFabError& error, void* customData)
+    void PlayFabTestMultiUserStatic::MultiUserProfile2Failure(const PlayFabError& error, void* /*customData*/)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-        testContext->Fail("Failed to get user 2 profile: " + error.GenerateErrorReport());
+        multiUser2Error = "Failed to get user 2 profile: " + error.GenerateErrorReport();
+        thread2Complete = true;
     }
 
     void PlayFabTestMultiUserStatic::MultiUserLogin(TestContext& testContext)
@@ -77,6 +77,7 @@ namespace PlayFabUnit
         LoginWithCustomIDRequest user2LoginRequest;
         user2LoginRequest.CustomId = "test_MultiStatic2";
         user2LoginRequest.CreateAccount = true;
+        user2LoginRequest.authenticationContext = multiUser2Context;
 
         const auto& user2LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user2LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
@@ -90,30 +91,55 @@ namespace PlayFabUnit
 
     void PlayFabTestMultiUserStatic::ClassSetUp()
     {
+        // Ref or create contexts for players
+        multiUser1Context = PlayFabSettings::staticPlayer;
+        multiUser2Context = std::make_shared<PlayFabAuthenticationContext>();
+    }
+
+    void PlayFabTestMultiUserStatic::SetUp(TestContext& /*testContext*/)
+    {
         // Make sure PlayFab state is clean.
         PlayFabSettings::ForgetAllCredentials();
 
         // Reset state variables.
-        multiUser1PlayFabId = "";
-        multiUser2PlayFabId = "";
+        multiUser1Error.clear();
+        multiUser2Error.clear();
+        thread1Complete = false;
+        thread2Complete = false;
     }
 
     void PlayFabTestMultiUserStatic::Tick(TestContext& testContext)
     {
-        // Wait for both users to become logged in.
-        if (multiUser1PlayFabId.empty() || multiUser2PlayFabId.empty())
+        // Wait for both threads to stop
+        if (!thread1Complete || !thread2Complete)
             return;
 
-        // Once retreived, each user should have a unique ID.
+        // Once retrieved, each user should have a unique ID.
+        if (!multiUser1Error.empty() || !multiUser2Error.empty())
+        {
+            testContext.Fail(multiUser1Error + multiUser2Error);
+            return;
+        }
+
+        std::string multiUser1PlayFabId = multiUser1Context->playFabId;
+        std::string multiUser2PlayFabId = multiUser2Context->playFabId;
+
         if (multiUser1PlayFabId == multiUser2PlayFabId)
             testContext.Fail("User 1 PlayFabId (" + multiUser1PlayFabId + ") should not match User 2 PlayFabId (" + multiUser2PlayFabId + ")");
         else
             testContext.Pass();
     }
 
+    void PlayFabTestMultiUserStatic::TearDown(TestContext& /*testContext*/)
+    {
+        // Clean up PlayFab state for next TestCase.
+        PlayFabSettings::ForgetAllCredentials();
+    }
+
     void PlayFabTestMultiUserStatic::ClassTearDown()
     {
-        // Clean up any PlayFab state for next TestCase.
-        PlayFabSettings::ForgetAllCredentials();
+        // Release contexts
+        multiUser1Context = nullptr; // This one isn't destroyed because it's PlayFabSettings::staticPlayer
+        multiUser2Context = nullptr;
     }
 }

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.h
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.h
@@ -19,30 +19,34 @@ namespace PlayFabUnit
 {
     class PlayFabTestMultiUserStatic : public TestCase
     {
-        private:
-            /// <summary>
-            /// CLIENT API
-            /// Try to log in two users simultaneously using static APIs.
-            /// </summary>
-            std::string multiUser1PlayFabId;
-            std::string multiUser2PlayFabId;
+    private:
+        /// <summary>
+        /// CLIENT API
+        /// Try to log in two users simultaneously using static APIs.
+        /// </summary>
+        std::shared_ptr<PlayFab::PlayFabAuthenticationContext> multiUser1Context;
+        std::shared_ptr<PlayFab::PlayFabAuthenticationContext> multiUser2Context;
+        std::string multiUser1Error, multiUser2Error;
+        bool thread1Complete, thread2Complete;
 
-            void MultiUserLogin1Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
-            void MultiUserLogin1Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserProfile1Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
-            void MultiUserProfile1Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserLogin2Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
-            void MultiUserLogin2Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserProfile2Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
-            void MultiUserProfile2Failure(const PlayFab::PlayFabError& error, void* customData);
-            void MultiUserLogin(TestContext& testContext);
+        void MultiUserLogin1Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        void MultiUserLogin1Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserProfile1Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
+        void MultiUserProfile1Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserLogin2Success(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        void MultiUserLogin2Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserProfile2Success(const PlayFab::ClientModels::GetPlayerProfileResult& result, void* customData);
+        void MultiUserProfile2Failure(const PlayFab::PlayFabError& error, void* customData);
+        void MultiUserLogin(TestContext& testContext);
 
-        protected:
-            void AddTests() override;
+    protected:
+        void AddTests() override;
 
-        public:
-            void ClassSetUp() override;
-            void Tick(TestContext& testContext) override;
-            void ClassTearDown() override;
+    public:
+        void ClassSetUp() override;
+        void SetUp(TestContext& testContext) override;
+        void Tick(TestContext& testContext) override;
+        void TearDown(TestContext& testContext) override;
+        void ClassTearDown() override;
     };
 }

--- a/source/test/TestApp/TestContext.cpp
+++ b/source/test/TestApp/TestContext.cpp
@@ -19,83 +19,83 @@ namespace PlayFabUnit
         {
             switch (state)
             {
-                case PlayFabUnit::TestFinishState::PASSED:
-                    testResultMsg += "Test try to Pass twice for some reason.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::FAILED:
-                    testResultMsg += "Test try to Fail after Passing.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::SKIPPED:
-                    testResultMsg += "Test try to be Skipped after Passing.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::TIMEDOUT:
-                    testResultMsg += "Test try to Timeout after Passing.\n";
-                    break;
-                default:
-                    testResultMsg += "How are you switching back to a Pending state from Passing.\n";
-                    break;
+            case PlayFabUnit::TestFinishState::PASSED:
+                testResultMsg += "Tests should not attempt to pass twice.";
+                break;
+            case PlayFabUnit::TestFinishState::FAILED:
+                testResultMsg += "Test try to Fail after Passing. " + resultMsg;
+                break;
+            case PlayFabUnit::TestFinishState::SKIPPED:
+                testResultMsg += "Test try to be Skipped after Passing.";
+                break;
+            case PlayFabUnit::TestFinishState::TIMEDOUT:
+                testResultMsg += "Test try to Timeout after Passing.";
+                break;
+            default:
+                testResultMsg += "How are you switching back to a Pending state from Passing.";
+                break;
             }
         }
-        else if(finishState == TestFinishState::FAILED) 
-        {
-            switch (state)
-            {
-                case PlayFabUnit::TestFinishState::PASSED:
-                    testResultMsg += "Test try to Pass after Failing.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::FAILED:
-                    testResultMsg += "Test try to Fail twice.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::SKIPPED:
-                    testResultMsg += "Test try to be Skipped after Failing.\n";
-                    break;
-                case PlayFabUnit::TestFinishState::TIMEDOUT:
-                    testResultMsg += "Test try to Timeout after Failing.\n";
-                    break;
-                default:
-                    testResultMsg += "How are you switching back to a Pending state from Failing.\n";
-                    break;
-            }
-        }
-        else if(finishState == TestFinishState::SKIPPED)
+        else if (finishState == TestFinishState::FAILED)
         {
             switch (state)
             {
             case PlayFabUnit::TestFinishState::PASSED:
-                testResultMsg += "Test try to Pass after being Skipped.\n";
+                testResultMsg += "Test try to Pass after Failing.";
                 break;
             case PlayFabUnit::TestFinishState::FAILED:
-                testResultMsg += "Test try to Fail after being Skipped.\n";
+                testResultMsg += "Test try to Fail twice. " + resultMsg;
                 break;
             case PlayFabUnit::TestFinishState::SKIPPED:
-                testResultMsg += "Test try to be Skipped twice.\n";
+                testResultMsg += "Test try to be Skipped after Failing.";
                 break;
             case PlayFabUnit::TestFinishState::TIMEDOUT:
-                testResultMsg += "Test try to Timeout after being Skipped.\n";
+                testResultMsg += "Test try to Timeout after Failing.";
                 break;
             default:
-                testResultMsg += "How are you switching back to a Pending state from Skipping.\n";
+                testResultMsg += "How are you switching back to a Pending state from Failing.";
                 break;
             }
         }
-        else 
+        else if (finishState == TestFinishState::SKIPPED)
         {
             switch (state)
             {
             case PlayFabUnit::TestFinishState::PASSED:
-                testResultMsg += "Test try to Pass after being Timeout.\n";
+                testResultMsg += "Test try to Pass after being Skipped.";
                 break;
             case PlayFabUnit::TestFinishState::FAILED:
-                testResultMsg += "Test try to Fail after being Timeout.\n";
+                testResultMsg += "Test try to Fail after being Skipped. " + resultMsg;
                 break;
             case PlayFabUnit::TestFinishState::SKIPPED:
-                testResultMsg += "Test try to be Skipped after being Timeout.\n";
+                testResultMsg += "Test try to be Skipped twice.";
                 break;
             case PlayFabUnit::TestFinishState::TIMEDOUT:
-                testResultMsg += "Test try to Timeout twice.\n";
+                testResultMsg += "Test try to Timeout after being Skipped.";
                 break;
             default:
-                testResultMsg += "How are you switching back to a Pending state from Timing Out.\n";
+                testResultMsg += "How are you switching back to a Pending state from Skipping.";
+                break;
+            }
+        }
+        else
+        {
+            switch (state)
+            {
+            case PlayFabUnit::TestFinishState::PASSED:
+                testResultMsg += "Test try to Pass after being Timeout.";
+                break;
+            case PlayFabUnit::TestFinishState::FAILED:
+                testResultMsg += "Test try to Fail after being Timeout.";
+                break;
+            case PlayFabUnit::TestFinishState::SKIPPED:
+                testResultMsg += "Test try to be Skipped after being Timeout.";
+                break;
+            case PlayFabUnit::TestFinishState::TIMEDOUT:
+                testResultMsg += "Test try to Timeout twice.";
+                break;
+            default:
+                testResultMsg += "How are you switching back to a Pending state from Timing Out.";
                 break;
             }
         }

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -14,7 +14,7 @@ namespace PlayFabUnit
 {
     static const auto TEST_TIMEOUT_DURATION = std::chrono::seconds(15);
 
-    TestRunner::TestRunner():
+    TestRunner::TestRunner() :
         suiteState(TestActiveState::PENDING),
         suiteTestCase(nullptr),
         suiteTestReport(PlayFabSettings::buildIdentifier)
@@ -39,10 +39,10 @@ namespace PlayFabUnit
             suiteState = TestActiveState::ACTIVE;
 
         // Run the tests.
-        for (auto testsIter = suiteTests.begin(); testsIter != suiteTests.end(); ++testsIter)
+        for (auto& suiteTest : suiteTests)
         {
             // Get the next test.
-            TestContext* test = **testsIter;
+            TestContext* test = *suiteTest;
 
             // Handle transitions between TestCases.
             ManageTestCase(test->testCase, suiteTestCase);

--- a/templates/PlayFab_API.h.ejs
+++ b/templates/PlayFab_API.h.ejs
@@ -1,7 +1,6 @@
 #pragma once
 
 <%- getApiDefine(api) %>
-#ifndef PLAYFAB_DISABLE_STATIC_API
 
 #include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFab<%- api.name %>DataModels.h>
@@ -40,5 +39,4 @@ namespace PlayFab
     };
 }
 
-#endif // PLAYFAB_DISABLE_STATIC_API
 #endif // <%- getApiDefine(api) %>

--- a/templates/PlayFab_API.h.ejs
+++ b/templates/PlayFab_API.h.ejs
@@ -1,6 +1,7 @@
 #pragma once
 
 <%- getApiDefine(api) %>
+#ifndef PLAYFAB_DISABLE_STATIC_API
 
 #include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFab<%- api.name %>DataModels.h>
@@ -34,9 +35,10 @@ namespace PlayFab
 <% } %>
 <% if (hasClientOptions) { %>
         // Private, Client-Specific
-        static void MultiStepClientLogin(bool needsAttribution);
+        static void MultiStepClientLogin(std::shared_ptr<PlayFabAuthenticationContext> context, bool needsAttribution);
 <% } %>        static bool ValidateResult(PlayFabResultCommon& resultCommon, const CallRequestContainer& container);
     };
 }
 
-#endif
+#endif // PLAYFAB_DISABLE_STATIC_API
+#endif // <%- getApiDefine(api) %>

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -1,7 +1,6 @@
 #include <stdafx.h>
 
 <%- getApiDefine(api) %>
-#ifndef PLAYFAB_DISABLE_STATIC_API
 
 #include <playfab/PlayFab<%- api.name %>Api.h>
 #include <playfab/PlayFabPluginManager.h>
@@ -124,7 +123,6 @@ namespace PlayFab
     }
 }
 
-#endif // PLAYFAB_DISABLE_STATIC_API
 #endif // <%- getApiDefine(api) %>
 
 #if defined(PLAYFAB_PLATFORM_WINDOWS)

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -93,12 +93,15 @@ namespace PlayFab
         {
             AttributeInstallRequest request;
             if (context->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+            {
                 request.Idfa = context->advertisingIdValue;
+                AttributeInstall(request, nullptr, nullptr);
+            }
             else if (context->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+            {
                 request.Adid = context->advertisingIdValue;
-            else
-                return;
-            AttributeInstall(request, nullptr, nullptr);
+                AttributeInstall(request, nullptr, nullptr);
+            }
         }
     }
 <% } %>

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -1,6 +1,7 @@
 #include <stdafx.h>
 
 <%- getApiDefine(api) %>
+#ifndef PLAYFAB_DISABLE_STATIC_API
 
 #include <playfab/PlayFab<%- api.name %>Api.h>
 #include <playfab/PlayFabPluginManager.h>
@@ -36,6 +37,8 @@ namespace PlayFab
         void* customData
     )
     {
+        std::shared_ptr<PlayFabAuthenticationContext> context = request.authenticationContext != nullptr ? request.authenticationContext : PlayFabSettings::staticPlayer;
+        std::shared_ptr<PlayFabApiSettings> settings = PlayFabSettings::staticSettings;
 <%- getRequestActions("        ", apiCall, false) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const Json::Value requestJson = request.ToJson();
@@ -50,20 +53,20 @@ namespace PlayFab
             headers,
             jsonAsString,
             On<%- apiCall.name %>Result,
+            settings,
+            context,
             customData));
 
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
-        if (PlayFabSettings::ValidateSettings(request.authenticationContext, nullptr, *reqContainer))
-        {
-            http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
-        }
+        http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
     }
 
     void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, const std::string& result, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
     {
         CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
+        std::shared_ptr<PlayFabAuthenticationContext> context = container.GetContext();
 
         <%- apiCall.result %> outResult;
         if (ValidateResult(outResult, container))
@@ -81,18 +84,18 @@ namespace PlayFab
     // Private PlayFabClientAPI specific
     bool PlayFabClientAPI::IsClientLoggedIn()
     {
-        return !PlayFabSettings::clientSessionTicket.empty();
+        return !PlayFabSettings::staticPlayer->clientSessionTicket.empty();
     }
 
-    void PlayFabClientAPI::MultiStepClientLogin(bool needsAttribution)
+    void PlayFabClientAPI::MultiStepClientLogin(std::shared_ptr<PlayFabAuthenticationContext> context, bool needsAttribution)
     {
-        if (needsAttribution && !PlayFabSettings::disableAdvertising && PlayFabSettings::advertisingIdType.length() > 0 && PlayFabSettings::advertisingIdValue.length() > 0)
+        if (needsAttribution && !context->disableAdvertising && context->advertisingIdType.length() > 0 && context->advertisingIdValue.length() > 0)
         {
             AttributeInstallRequest request;
-            if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
-                request.Idfa = PlayFabSettings::advertisingIdValue;
-            else if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
-                request.Adid = PlayFabSettings::advertisingIdValue;
+            if (context->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+                request.Idfa = context->advertisingIdValue;
+            else if (context->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+                request.Adid = context->advertisingIdValue;
             else
                 return;
             AttributeInstall(request, nullptr, nullptr);
@@ -118,7 +121,8 @@ namespace PlayFab
     }
 }
 
-#endif
+#endif // PLAYFAB_DISABLE_STATIC_API
+#endif // <%- getApiDefine(api) %>
 
 #if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (default: 4100) // formal parameters are part of a public interface

--- a/templates/PlayFab_InstanceAPI.h.ejs
+++ b/templates/PlayFab_InstanceAPI.h.ejs
@@ -16,14 +16,24 @@ namespace PlayFab
     class PlayFab<%- api.name %>InstanceAPI
     {
     private:
-        std::shared_ptr<PlayFabApiSettings> settings;
-        std::shared_ptr<PlayFabAuthenticationContext> authContext;
+        std::shared_ptr<PlayFabApiSettings> m_settings{ nullptr };
+        std::shared_ptr<PlayFabAuthenticationContext> m_context{ nullptr };
 
     public:
-        PlayFab<%- api.name %>InstanceAPI();
+<% if( api.name === "Admin" || api.name === "Server" ) {
+%>        PlayFab<%- api.name %>InstanceAPI();
         explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings);
         explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
         PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+<% } else if( api.name === "Client" || api.name === "Authentication" ) {
+%>        PlayFab<%- api.name %>InstanceAPI();
+        explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings);
+        explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+        PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+<% } else {
+%>        explicit PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+        PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
+<% } %>
         ~PlayFab<%- api.name %>InstanceAPI();
         PlayFab<%- api.name %>InstanceAPI(const PlayFab<%- api.name %>InstanceAPI& source) = delete; // disable copy
         PlayFab<%- api.name %>InstanceAPI(PlayFab<%- api.name %>InstanceAPI&&) = delete; // disable move
@@ -31,9 +41,7 @@ namespace PlayFab
         PlayFab<%- api.name %>InstanceAPI& operator=(PlayFab<%- api.name %>InstanceAPI&& other) = delete; // disable move assignment
 
         std::shared_ptr<PlayFabApiSettings> GetSettings() const;
-        void SetSettings(std::shared_ptr<PlayFabApiSettings> apiSettings);
         std::shared_ptr<PlayFabAuthenticationContext> GetAuthenticationContext() const;
-        void SetAuthenticationContext(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext);
         size_t Update();
         void ForgetAllCredentials();
 <% if (hasClientOptions) { %>
@@ -50,10 +58,8 @@ namespace PlayFab
 <% }
 if (hasClientOptions) { %>
         // Private, Client-Specific
-        void MultiStepClientLogin(bool needsAttribution);
+        void MultiStepClientLogin(std::shared_ptr<PlayFabAuthenticationContext> context, bool needsAttribution);
 <% } %>        bool ValidateResult(PlayFabResultCommon& resultCommon, const CallRequestContainer& container);
-    private:
-        std::shared_ptr<PlayFabAuthenticationContext> GetOrCreateAuthenticationContext();
     };
 }
 

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -15,59 +15,76 @@
 namespace PlayFab
 {
     using namespace <%- api.name %>Models;
-
+<% if( api.name === "Admin" || api.name === "Server" ) { %>
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI()
     {
     }
 
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings)
     {
-        this->settings = std::move(apiSettings);
+        this->m_settings = apiSettings;
     }
 
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
     {
-        this->authContext = std::move(authenticationContext);
+        this->m_context = authenticationContext;
     }
 
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
     {
-        this->settings = std::move(apiSettings);
-        this->authContext = std::move(authenticationContext);
+        this->m_settings = apiSettings;
+        this->m_context = authenticationContext;
+    }
+<% } else if( api.name === "Client" || api.name === "Authentication" ) { %>
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI()
+    {
+        this->m_context = std::make_shared<PlayFabAuthenticationContext>();
     }
 
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings)
+    {
+        this->m_settings = apiSettings;
+        this->m_context = std::make_shared<PlayFabAuthenticationContext>();
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        this->m_context = authenticationContext;
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        this->m_settings = apiSettings;
+        this->m_context = authenticationContext;
+    }
+<% } else { %>
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        if (authenticationContext == nullptr)
+            throw PlayFabException(PlayFabExceptionCode::AuthContextRequired, "Context cannot be null, create a PlayFabAuthenticationContext for each player in advance, or get <PlayFabClientInstanceAPI>.authenticationContext");
+        this->m_context = authenticationContext;
+    }
+
+    PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
+    {
+        if (authenticationContext == nullptr)
+            throw PlayFabException(PlayFabExceptionCode::AuthContextRequired, "Context cannot be null, create a PlayFabAuthenticationContext for each player in advance, or get <PlayFabClientInstanceAPI>.authenticationContext");
+        this->m_settings = apiSettings;
+        this->m_context = authenticationContext;
+    }
+<% } %>
     PlayFab<%- api.name %>InstanceAPI::~PlayFab<%- api.name %>InstanceAPI()
     {
     }
 
     std::shared_ptr<PlayFabApiSettings> PlayFab<%- api.name %>InstanceAPI::GetSettings() const
     {
-        return this->settings;
-    }
-
-    void PlayFab<%- api.name %>InstanceAPI::SetSettings(std::shared_ptr<PlayFabApiSettings> apiSettings)
-    {
-        this->settings = std::move(apiSettings);
+        return this->m_settings;
     }
 
     std::shared_ptr<PlayFabAuthenticationContext> PlayFab<%- api.name %>InstanceAPI::GetAuthenticationContext() const
     {
-        return this->authContext;
-    }
-
-    void PlayFab<%- api.name %>InstanceAPI::SetAuthenticationContext(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
-    {
-        this->authContext = std::move(authenticationContext);
-    }
-
-    std::shared_ptr<PlayFabAuthenticationContext> PlayFab<%- api.name %>InstanceAPI::GetOrCreateAuthenticationContext()
-    {
-        if (this->authContext == nullptr)
-        {
-            this->authContext = std::make_shared<PlayFabAuthenticationContext>();
-        }
-        
-        return this->authContext;
+        return this->m_context;
     }
 
     size_t PlayFab<%- api.name %>InstanceAPI::Update()
@@ -78,10 +95,10 @@ namespace PlayFab
 
     void PlayFab<%- api.name %>InstanceAPI::ForgetAllCredentials()
     {
-        if (this->authContext == nullptr)
+        if (this->m_context == nullptr)
             return;
 
-        this->authContext->ForgetAllCredentials();
+        this->m_context->ForgetAllCredentials();
     }
 
     // PlayFab<%- api.name %> instance APIs
@@ -93,12 +110,14 @@ namespace PlayFab
         void* customData
     )
     {
+        std::shared_ptr<PlayFabAuthenticationContext> context = request.authenticationContext != nullptr ? request.authenticationContext : this->m_context;
+        std::shared_ptr<PlayFabApiSettings> settings = this->m_settings != nullptr ? this->m_settings : PlayFabSettings::staticSettings;
 <%- getRequestActions("        ", apiCall, true) %>
         IPlayFabHttpPlugin& http = *PlayFabPluginManager::GetPlugin<IPlayFabHttpPlugin>(PlayFabPluginContract::PlayFab_Transport);
         const Json::Value requestJson = request.ToJson();
         std::string jsonAsString = requestJson.toStyledString();
 
-        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = request.authenticationContext == nullptr ? this->GetOrCreateAuthenticationContext() : request.authenticationContext;
+        std::shared_ptr<PlayFabAuthenticationContext> authenticationContext = request.authenticationContext == nullptr ? this->m_context : request.authenticationContext;
         std::unordered_map<std::string, std::string> headers;
 <% if (hasAuthParams(apiCall)) {
 %>        headers.emplace(<%- getAuthParams(apiCall, true) %>);
@@ -108,21 +127,20 @@ namespace PlayFab
             headers,
             jsonAsString,
             std::bind(&PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3),
-            customData,
-            this->settings));
+            settings,
+            context,
+            customData));
 
         reqContainer->successCallback = std::shared_ptr<void>((callback == nullptr) ? nullptr : new ProcessApiCallback<<%- apiCall.result %>>(callback));
         reqContainer->errorCallback = errorCallback;
 
-        if (PlayFabSettings::ValidateSettings(authenticationContext, this->settings, *reqContainer))
-        {
-            http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
-        }
+        http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
     }
 
     void PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result(int httpCode, const std::string& result, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
     {
         CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
+        std::shared_ptr<PlayFabAuthenticationContext> context = container.GetContext();
 
         <%- apiCall.result %> outResult;
         if (ValidateResult(outResult, container))
@@ -140,39 +158,21 @@ namespace PlayFab
     // Private PlayFabClientInstanceAPI specific
     bool PlayFabClientInstanceAPI::IsClientLoggedIn()
     {
-        return !this->GetOrCreateAuthenticationContext()->clientSessionTicket.empty();
+        return !this->m_context->clientSessionTicket.empty();
     }
 
-    void PlayFabClientInstanceAPI::MultiStepClientLogin(bool needsAttribution)
+    void PlayFabClientInstanceAPI::MultiStepClientLogin(std::shared_ptr<PlayFabAuthenticationContext> context, bool needsAttribution)
     {
-        std::shared_ptr<PlayFab::PlayFabApiSettings> apiSettings = this->GetSettings();
-        if (apiSettings == nullptr)
+        if (needsAttribution && !context->disableAdvertising && context->advertisingIdType.length() > 0 && context->advertisingIdValue.length() > 0)
         {
-            if (needsAttribution && !PlayFabSettings::disableAdvertising && PlayFabSettings::advertisingIdType.length() > 0 && PlayFabSettings::advertisingIdValue.length() > 0)
-            {
-                AttributeInstallRequest request;
-                if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
-                    request.Idfa = PlayFabSettings::advertisingIdValue;
-                else if (PlayFabSettings::advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
-                    request.Adid = PlayFabSettings::advertisingIdValue;
-                else
-                    return;
-                AttributeInstall(request, nullptr, nullptr);
-            }
-        }
-        else
-        {
-            if (needsAttribution && !apiSettings->disableAdvertising && apiSettings->advertisingIdType.length() > 0 && apiSettings->advertisingIdValue.length() > 0)
-            {
-                AttributeInstallRequest request;
-                if (apiSettings->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
-                    request.Idfa = apiSettings->advertisingIdValue;
-                else if (apiSettings->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
-                    request.Adid = apiSettings->advertisingIdValue;
-                else
-                    return;
-                AttributeInstall(request, nullptr, nullptr);
-            }
+            AttributeInstallRequest request;
+            if (context->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+                request.Idfa = context->advertisingIdValue;
+            else if (context->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+                request.Adid = context->advertisingIdValue;
+            else
+                return;
+            AttributeInstall(request, nullptr, nullptr);
         }
     }
 <% } %>

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -61,14 +61,18 @@ namespace PlayFab
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
     {
         if (authenticationContext == nullptr)
+        {
             throw PlayFabException(PlayFabExceptionCode::AuthContextRequired, "Context cannot be null, create a PlayFabAuthenticationContext for each player in advance, or get <PlayFabClientInstanceAPI>.authenticationContext");
+        }
         this->m_context = authenticationContext;
     }
 
     PlayFab<%- api.name %>InstanceAPI::PlayFab<%- api.name %>InstanceAPI(std::shared_ptr<PlayFabApiSettings> apiSettings, std::shared_ptr<PlayFabAuthenticationContext> authenticationContext)
     {
         if (authenticationContext == nullptr)
+        {
             throw PlayFabException(PlayFabExceptionCode::AuthContextRequired, "Context cannot be null, create a PlayFabAuthenticationContext for each player in advance, or get <PlayFabClientInstanceAPI>.authenticationContext");
+        }
         this->m_settings = apiSettings;
         this->m_context = authenticationContext;
     }
@@ -95,10 +99,10 @@ namespace PlayFab
 
     void PlayFab<%- api.name %>InstanceAPI::ForgetAllCredentials()
     {
-        if (this->m_context == nullptr)
-            return;
-
-        this->m_context->ForgetAllCredentials();
+        if (this->m_context != nullptr)
+        {
+            this->m_context->ForgetAllCredentials();
+        }
     }
 
     // PlayFab<%- api.name %> instance APIs
@@ -167,12 +171,15 @@ namespace PlayFab
         {
             AttributeInstallRequest request;
             if (context->advertisingIdType == PlayFabSettings::AD_TYPE_IDFA)
+            {
                 request.Idfa = context->advertisingIdValue;
+                AttributeInstall(request, nullptr, nullptr);
+            }
             else if (context->advertisingIdType == PlayFabSettings::AD_TYPE_ANDROID_ID)
+            {
                 request.Adid = context->advertisingIdValue;
-            else
-                return;
-            AttributeInstall(request, nullptr, nullptr);
+                AttributeInstall(request, nullptr, nullptr);
+            }
         }
     }
 <% } %>


### PR DESCRIPTION
# Change description

* Several PlayFabSettings fields are moved to PlayFabSettings::staticPlayer or PlayFabSettings::staticSettings
* Some fields shuffled between PlayFabApiSettings and PlayFabAuthenticationContext based on appropriate-ness
* CallRequestContainer takes on more work, including referencing settings & context pointers and ValidateSettings
* New PlayFabException, which will replace std::runtime_error in several places, and will show up in more places in future commits
* Many settings & context member fields have been renamed to m_settings & m_context to avoid name conflicts
* Fixed standard tabbing issues in a lot of files
* Fixed multi-instance tests to not crash the program, if the calls fail.
* TestContext reports multiple failure outcomes slightly better.
* Instance API construction utilizes the more intuitive pattern established in C#
* Instance APIs will never read from, or write to the staticPlayer (This is the primary data leak)

# List of breaking changes:

High visibility breaking changes:

* PlayFabSettings::titleId is moved to PlayFabSettings::staticSettings->titleId
   * Severity: low, impacted customers: 100%, customer difficulty inflicted: easy
* PlayFabSettings::developerSecretKey is moved to PlayFabSettings::staticSettings->developerSecretKey
   * Severity: low, impacted customers: many, customer difficulty inflicted: easy

High impact, but low visibility breaking changes:

* PlayFabSettings::ValidateSettings() moved to CallRequestContainer
    * Severity: medium, impacted customers: ~none, customer difficulty inflicted: moderate
    * Defense: ValidateSettings is an internal use method which had no good reason to be in public PlayFabSettings
* Moved PlayFabApiSettings from CallRequestContainerBase to CallRequestContainer
    * Affects constructor, member methods and protected fields
    * Severity: medium, impacted customers: ~none, customer difficulty inflicted: moderate
    * Defense: It was a design violation for PlayFab specific objects to be in the base CRC
* Added PlayFabAuthenticationContext to CallRequestContainer
    * Affects constructor, member methods and protected fields
    * Severity: medium, impacted customers: ~none, customer difficulty inflicted: moderate
    * Defense: It's simply necessary for the instance data isolation. It's 100% required, and there's no good alternative.
* Added new PlayFabException throws from ApiInstance constructor under invalid conditions
    * Severity: medium, impacted customers: very low, customer difficulty inflicted: moderate
    * Defense: Any customer that triggers the new exception wasn't using instances correctly. If their previous instances worked, they were exploiting the data-leak bug that this commit will correct

Trivial breaking changes unlikely to affect customers

* PlayFabAuthenticationContext::developerSecretKey is moved to PlayFabApiSettings
   * Severity: low, impacted customers: few, customer difficulty inflicted: easy
* PlayFabSettings::verticalName removed
    * Severity: none, impacted customers: none, customer difficulty inflicted: none
* PlayFabApiSettings.verticalName removed
    * Severity: none, impacted customers: none, customer difficulty inflicted: none
* PlayFabSettings::requestParams moved to PlayFabApiSettings
    * Severity: very low, impacted customers: ~none, customer difficulty inflicted: none
* PlayFabSettings::useDevelopmentEnvironment removed
    * Severity: none, impacted customers: none, customer difficulty inflicted: none
* PlayFabSettings::developmentEnvironmentURL removed
    * Severity: none, impacted customers: none, customer difficulty inflicted: none
* PlayFabSettings::entityToken moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: very low, customer difficulty inflicted: easy
* PlayFabSettings::clientSessionTicket moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: very low, customer difficulty inflicted: easy
* PlayFabSettings::advertisingIdType moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabSettings::advertisingIdValue moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabSettings::GetUrl() redirected to same method in PlayFabApiSettings
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabSettings::GetUrl() method signature changed
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabApiSettings.advertisingIdType moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabApiSettings.advertisingIdValue moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* PlayFabApiSettings.disableAdvertising moved to PlayFabAuthenticationContext
    * Severity: low, impacted customers: ~none, customer difficulty inflicted: easy
* Created PlayFabException, replaced several std::runtime_error instances with PlayFabException
    * Severity: none, impacted customers: none, customer difficulty inflicted: none
* Altered the print output of failing unit tests, for better debug-ability and readability
    * Severity: none, impacted customers: ~none, customer difficulty inflicted: ~none
* Fixed MultiStepClientLogin in API instances, such that it will work in circumstances where it would previously fail silently
    * Severity: none, impacted customers: ~none, customer difficulty inflicted: ~none


Because it's hard to see how template changes affect the SDK, I've made an example PR with the generated template here:
https://github.com/PlayFab/XPlatCppSdk/pull/30