### PR TITLE
Move all platform-specific timestamp manipulation to a single new PlatformUtils.h file

### DIFF
--- a/source/build/Windows/XPlatCppWindows.vcxproj.ejs
+++ b/source/build/Windows/XPlatCppWindows.vcxproj.ejs
@@ -110,6 +110,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformMacros.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformUtils.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />
@@ -171,7 +172,7 @@
     <ProjectReference Include="..\..\external\jsoncpp-build\lib_json.vcxproj">
       <Project>{1e6c2c1c-6453-4129-ae3f-0ee8e6599c89}</Project>
     </ProjectReference>
-  </ItemGroup>  
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
+++ b/source/build/Windows/XPlatCppWindows.vcxproj.filters.ejs
@@ -26,6 +26,9 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformMacros.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformUtils.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>

--- a/source/build/Xbox/XPlatXbox.vcxproj.ejs
+++ b/source/build/Xbox/XPlatXbox.vcxproj.ejs
@@ -170,6 +170,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformMacros.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformUtils.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabBaseModel.h" />

--- a/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
+++ b/source/build/Xbox/XPlatXbox.vcxproj.filters.ejs
@@ -26,6 +26,9 @@
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformMacros.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabPlatformUtils.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
     <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
       <Filter>Header Files\playfab</Filter>
     </ClInclude>

--- a/source/build/iOS/XPlatCppIOS/XPlatCppIOS.xcodeproj/project.pbxproj
+++ b/source/build/iOS/XPlatCppIOS/XPlatCppIOS.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		5A3F09B922418B1500AC0816 /* PlayFabMultiplayerDataModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabMultiplayerDataModels.h; path = ../../../code/include/playfab/PlayFabMultiplayerDataModels.h; sourceTree = "<group>"; };
 		5A3F09BA22418B1500AC0816 /* PlayFabServerDataModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabServerDataModels.h; path = ../../../code/include/playfab/PlayFabServerDataModels.h; sourceTree = "<group>"; };
 		5A3F09BC22418B1500AC0816 /* PlayFabPlatformMacros.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabPlatformMacros.h; path = ../../../code/include/playfab/PlayFabPlatformMacros.h; sourceTree = "<group>"; };
+		5A3F09BC22418B1500AC0816 /* PlayFabPlatformUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabPlatformUtils.h; path = ../../../code/include/playfab/PlayFabPlatformUtils.h; sourceTree = "<group>"; };
 		5A3F09BD22418B1500AC0816 /* PlayFabMultiplayerApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabMultiplayerApi.h; path = ../../../code/include/playfab/PlayFabMultiplayerApi.h; sourceTree = "<group>"; };
 		5A3F09BE22418B1500AC0816 /* PlayFabAuthenticationDataModels.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabAuthenticationDataModels.h; path = ../../../code/include/playfab/PlayFabAuthenticationDataModels.h; sourceTree = "<group>"; };
 		5A3F09BF22418B1500AC0816 /* PlayFabServerInstanceApi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = PlayFabServerInstanceApi.h; path = ../../../code/include/playfab/PlayFabServerInstanceApi.h; sourceTree = "<group>"; };
@@ -245,6 +246,7 @@
 				5A3F09B922418B1500AC0816 /* PlayFabMultiplayerDataModels.h */,
 				5A3F09C022418B1500AC0816 /* PlayFabMultiplayerInstanceApi.h */,
 				5A3F09BC22418B1500AC0816 /* PlayFabPlatformMacros.h */,
+				5A3F09BC22418B1500AC0816 /* PlayFabPlatformUtils.h */,
 				5A3F09C522418B1600AC0816 /* PlayFabPluginManager.h */,
 				5A3F09C422418B1600AC0816 /* PlayFabProfilesApi.h */,
 				5A3F09D822418B1700AC0816 /* PlayFabProfilesDataModels.h */,

--- a/source/code/include/playfab/PlayFabBaseModel.h
+++ b/source/code/include/playfab/PlayFabBaseModel.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <memory>
 
 #include <playfab/PlayFabPlatformMacros.h>
 #include <playfab/PlayFabJsonHeaders.h>

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -7,7 +7,6 @@
 
 #include <playfab/PlayFabEvent.h>
 #include <playfab/PlayFabEventBuffer.h>
-#include <playfab/PlayFabAuthenticationContext.h>
 #include <mutex>
 
 namespace PlayFab

--- a/source/code/include/playfab/PlayFabPlatformMacros.h
+++ b/source/code/include/playfab/PlayFabPlatformMacros.h
@@ -40,6 +40,8 @@ typedef unsigned __int64 Uint64;
 typedef unsigned __int32 Uint32;
 typedef unsigned __int16 Uint16;
 #elif defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
+#include <cstdint>
+
 typedef int64_t Int64;
 typedef int32_t Int32;
 typedef int16_t Int16;

--- a/source/code/include/playfab/PlayFabPlatformMacros.h
+++ b/source/code/include/playfab/PlayFabPlatformMacros.h
@@ -30,3 +30,21 @@
 #if defined(_WIN32) && !defined(_DURANGO)
 #define PLAYFAB_PLATFORM_WINDOWS
 #endif //_WIN32
+
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+typedef signed __int64 Int64;
+typedef signed __int32 Int32;
+typedef signed __int16 Int16;
+
+typedef unsigned __int64 Uint64;
+typedef unsigned __int32 Uint32;
+typedef unsigned __int16 Uint16;
+#elif defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
+typedef int64_t Int64;
+typedef int32_t Int32;
+typedef int16_t Int16;
+
+typedef uint64_t Uint64;
+typedef uint32_t Uint32;
+typedef uint16_t Uint16;
+#endif

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -44,7 +44,7 @@ namespace PlayFab
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
         gmtime_s(&timeInfo, &now);
 #elif defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        timeInfo = *gmtime(&input);
+        timeInfo = *gmtime(&now);
 #endif
         char buff[64];
         strftime(buff, 64, "%Y-%m-%dT%H:%M:%S.000Z", &timeInfo);

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace PlayFab
+{
+    typedef std::chrono::time_point<std::chrono::system_clock> TimePoint;
+
+    inline TimePoint GetPlayFabTimePointNow()
+    {
+        return std::chrono::system_clock::now();
+    }
+
+    inline time_t GetPlayFabTimeTNow()
+    {
+        time_t now = std::chrono::system_clock::to_time_t(GetPlayFabTimePointNow());
+#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_SWITCH)
+        return static_cast<Json::Int64>(now);
+#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH
+        return now;
+#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH
+    }
+
+    inline void AppendIntToString(int value, std::string& output)
+    {
+        // itoa is not available in android
+        char buffer[16];
+#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
+        sprintf(buffer, "%d", value);
+#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_PLAYSTATION || PLAYFAB_PLATFORM_SWITCH
+        sprintf_s(buffer, "%d", value);
+#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_PLAYSTATION || PLAYFAB_PLATFORM_SWITCH
+        output.append(buffer);
+    }
+
+    inline std::string LocalTimeTToUtcString(time_t now)
+    {
+        std::string output;
+
+        tm timeInfo;
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+        gmtime_s(&timeInfo, &now);
+#elif defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        timeInfo = *gmtime(&input);
+#endif
+        char buff[64];
+        strftime(buff, 64, "%Y-%m-%dT%H:%M:%S.000Z", &timeInfo);
+        output = buff;
+
+        return output;
+    }
+
+    inline std::string LocalTimePointToUtcString(TimePoint now)
+    {
+        return LocalTimeTToUtcString(std::chrono::system_clock::to_time_t(now));
+    }
+
+    inline time_t UtcStringToLocalTimeT(std::string utcString)
+    {
+        time_t output;
+        tm timeStruct = {};
+
+        std::istringstream iss(utcString);
+        iss >> std::get_time(&timeStruct, "%Y-%m-%dT%T");
+#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        output = mktime(&timeStruct);
+#elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
+        output = timegm(&timeStruct);
+#else
+        output = _mkgmtime(&timeStruct);
+#endif
+
+        return output;
+    }
+}

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -27,8 +27,8 @@ namespace PlayFab
         bufferArray(std::unique_ptr<uint8_t[]>(new uint8_t[buffMask + 1])),
         buffStart((uint64_t)(bufferArray.get())),
         buffEnd(buffStart + buffMask + 1),
-        eventIndex(std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0))),
-        disabled(false)
+        disabled(false),
+        eventIndex(std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0)))
     {
         uint8_t *buffer = (uint8_t*)buffStart;
         memset(buffer, 0, buffMask + 1);

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -23,11 +23,11 @@ namespace PlayFab
     PlayFabEventBuffer::PlayFabEventBuffer(
         const size_t bufferSize) 
         :
+        disabled(false),
         buffMask(AdjustBufferSize(bufferSize) - 1),
         bufferArray(std::unique_ptr<uint8_t[]>(new uint8_t[buffMask + 1])),
         buffStart((uint64_t)(bufferArray.get())),
         buffEnd(buffStart + buffMask + 1),
-        disabled(false),
         eventIndex(std::shared_ptr<std::atomic<uint64_t>>(new std::atomic<uint64_t>(0)))
     {
         uint8_t *buffer = (uint8_t*)buffStart;

--- a/source/code/stdafx.h
+++ b/source/code/stdafx.h
@@ -25,6 +25,7 @@
 
 #include <playfab/PlayFabJsonHeaders.h>
 #include <playfab/PlayFabPlatformMacros.h>
+#include <playfab/PlayFabAuthenticationContext.h>
 
 #define UNREFERENCED_PARAMETER(P) (P)
 

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -1,18 +1,21 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include "TestAppPch.h"
-#include <string>
-#include <playfab/PlayFabClientApi.h>
+
+#include <chrono>
+
+#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabSettings.h>
-#include <playfab/PlayFabAuthenticationDataModels.h>
+
 #include <playfab/PlayFabAuthenticationApi.h>
+#include <playfab/PlayFabAuthenticationDataModels.h>
+#include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabClientDataModels.h>
-#include <playfab/PlayFabDataDataModels.h>
 #include <playfab/PlayFabDataApi.h>
-#include <playfab/PlayFabPlatformMacros.h>
+#include <playfab/PlayFabDataDataModels.h>
+
 #include "PlayFabApiTest.h"
 #include "TestContext.h"
-
 
 using namespace PlayFab;
 using namespace ClientModels;
@@ -35,12 +38,12 @@ namespace PlayFabUnit
 
     void PlayFabApiTest::OnErrorSharedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Unexpected error: " + error.ErrorMessage);
     }
 
-    /// CLIENT API
-    /// Try to deliberately cause a client-side validation error
+    // CLIENT API
+    // Try to deliberately cause a client-side validation error
     void PlayFabApiTest::InvalidSettings(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -57,13 +60,13 @@ namespace PlayFabUnit
             [&validTitleId](const LoginResult&, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            TestContext* testContext = static_cast<TestContext*>(customData);
             testContext->Fail("Expected API call to fail on the client side");
         },
             [&validTitleId](const PlayFabError& error, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            TestContext* testContext = static_cast<TestContext*>(customData);
             if (error.HttpCode == 0
                 && error.HttpStatus == "Client-side validation failure"
                 && error.ErrorCode == PlayFabErrorCode::PlayFabErrorInvalidParams
@@ -75,9 +78,9 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    /// CLIENT API
-    /// Try to deliberately log in with an inappropriate password,
-    ///   and verify that the error displays as expected.
+    // CLIENT API
+    // Try to deliberately log in with an inappropriate password,
+    //   and verify that the error displays as expected.
     void PlayFabApiTest::InvalidLogin(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -91,31 +94,28 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::LoginCallback(const LoginResult&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Expected login to fail");
     }
     void PlayFabApiTest::LoginFailedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (error.RequestId.empty())
         {
             testContext->Fail("The requestId should be set on a failure.");
         }
+        else if (error.ErrorMessage.find("password") != -1)
+        {
+            testContext->Pass(error.RequestId);
+        }
         else
-#endif // defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-            if (error.ErrorMessage.find("password") != -1)
-            {
-                testContext->Pass(error.RequestId);
-            }
-            else
-            {
-                testContext->Fail("Password error message not found: " + error.ErrorMessage);
-            }
+        {
+            testContext->Fail("Password error message not found: " + error.ErrorMessage);
+        }
     }
 
-    /// CLIENT API
-    /// Test that a lambda error callback can be successfully invoked
+    // CLIENT API
+    // Test that a lambda error callback can be successfully invoked
     void PlayFabApiTest::InvalidLoginLambda(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -124,13 +124,13 @@ namespace PlayFabUnit
 
         PlayFabClientAPI::LoginWithEmailAddress(request,
             nullptr,
-            [](const PlayFabError& error, void* customData) { TestContext* testContext = reinterpret_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
+            [](const PlayFabError& error, void* customData) { TestContext* testContext = static_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
             &testContext);
     }
 
-    /// CLIENT API
-    /// Try to deliberately register a user with an invalid email and password
-    ///   Verify that errorDetails are populated correctly.
+    // CLIENT API
+    // Try to deliberately register a user with an invalid email and password
+    //   Verify that errorDetails are populated correctly.
     void PlayFabApiTest::InvalidRegistration(TestContext& testContext)
     {
         RegisterPlayFabUserRequest request;
@@ -145,7 +145,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::InvalidRegistrationSuccess(const RegisterPlayFabUserResult&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Expected registration to fail");
     }
     void PlayFabApiTest::InvalidRegistrationFail(const PlayFabError& error, void* customData)
@@ -158,7 +158,7 @@ namespace PlayFabUnit
         foundEmailMsg = (errorReport.find(expectedEmailMsg) != -1);
         foundPasswordMsg = (errorReport.find(expectedPasswordMsg) != -1);
 
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (foundEmailMsg && foundPasswordMsg)
         {
             testContext->Pass();
@@ -169,8 +169,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Attempt a successful login
+    // CLIENT API
+    // Attempt a successful login
     void PlayFabApiTest::LoginOrRegister(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -185,12 +185,12 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginOrRegister(const LoginResult& result, void* customData)
     {
         playFabId = result.PlayFabId;
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test that the login call sequence sends the AdvertisingId when set
+    // CLIENT API
+    // Test that the login call sequence sends the AdvertisingId when set
     void PlayFabApiTest::LoginWithAdvertisingId(TestContext& testContext)
     {
         PlayFabSettings::staticPlayer->advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
@@ -209,15 +209,15 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginWithAdvertisingId(const LoginResult&, void* customData)
     {
         // TODO: Need to wait for the NEXT api call to complete, and then test PlayFabSettings::staticPlayer->advertisingIdType
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test a sequence of calls that modifies saved data,
-    ///   and verifies that the next sequential API call contains updated data.
-    /// Verify that the data is correctly modified on the next call.
-    /// Parameter types tested: string, Dictionary<string, string>, DateTime
+    // CLIENT API
+    // Test a sequence of calls that modifies saved data,
+    //   and verifies that the next sequential API call contains updated data.
+    // Verify that the data is correctly modified on the next call.
+    // Parameter types tested: string, Dictionary<string, string>
     void PlayFabApiTest::UserDataApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -241,15 +241,8 @@ namespace PlayFabUnit
         testMessageInt = (testMessageInt + 1) % 100;
         UpdateUserDataRequest updateRequest;
 
-        // itoa is not avaialable in android
-        char buffer[16];
         std::string temp;
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
-        sprintf(buffer, "%d", testMessageInt);
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
-        sprintf_s(buffer, "%d", testMessageInt);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
-        temp.append(buffer);
+        AppendIntToString(testMessageInt, temp);
 
         updateRequest.Data[TEST_DATA_KEY] = temp;
         PlayFabClientAPI::UpdateUserData(updateRequest,
@@ -269,23 +262,8 @@ namespace PlayFabUnit
     {
         auto it = result.Data.find(TEST_DATA_KEY);
         int actualDataValue = (it == result.Data.end()) ? -1 : atoi(it->second.Value.c_str());
-        testMessageTime = (it == result.Data.end()) ? 0 : it->second.LastUpdated;
 
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        time_t now = time(nullptr);
-        struct tm timeinfo;
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        timeinfo = *gmtime(&now);
-        now = timegm(&timeinfo);
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
-        gmtime_s(&timeinfo, &now);
-        now = _mkgmtime(&timeinfo);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
-        time_t minTime = now - (60 * 5);
-        time_t maxTime = now + (60 * 5);
-#endif // PLAYFAB_PLATFORM_PLAYSTATION
-
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (it == result.Data.end())
         {
             testContext->Fail("Expected user data not found.");
@@ -294,23 +272,49 @@ namespace PlayFabUnit
         {
             testContext->Fail("User data not updated as expected.");
         }
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION) // Issue 32699
-        else if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
-        {
-            testContext->Fail("DateTime not parsed correctly..");
-        }
-#endif // PLAYFAB_PLATFORM_PLAYSTATION
         else
         {
             testContext->Pass();
         }
     }
 
-    /// CLIENT API
-    /// Test a sequence of calls that modifies saved data,
-    ///   and verifies that the next sequential API call contains updated data.
-    /// Verify that the data is saved correctly, and that specific types are tested
-    /// Parameter types tested: Dictionary<string, int>
+    // CLIENT API
+    // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
+    // Parameter types tested: DateTime
+    void PlayFabApiTest::GetServerTime(TestContext& testContext)
+    {
+        if (!PlayFabClientAPI::IsClientLoggedIn())
+        {
+            testContext.Skip("Earlier tests failed to log in");
+            return;
+        }
+
+        GetTimeRequest request;
+        PlayFabClientAPI::GetTime(request,
+            Callback(&PlayFabApiTest::OnGetServerTime),
+            Callback(&PlayFabApiTest::OnErrorSharedCallback),
+            &testContext);
+    }
+    void PlayFabApiTest::OnGetServerTime(const GetTimeResult& result, void* customData)
+    {
+        testMessageTime = std::chrono::system_clock::from_time_t(result.Time);
+
+        TimePoint now = GetPlayFabTimePointNow();
+        TimePoint minTime = now - std::chrono::minutes(5);
+        TimePoint maxTime = now + std::chrono::minutes(5);
+
+        TestContext* testContext = static_cast<TestContext*>(customData);
+        if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
+            testContext->Fail("DateTime not parsed correctly.");
+        else
+            testContext->Pass();
+    }
+
+    // CLIENT API
+    // Test a sequence of calls that modifies saved data,
+    //   and verifies that the next sequential API call contains updated data.
+    // Verify that the data is saved correctly, and that specific types are tested
+    // Parameter types tested: Dictionary<string, int>
     void PlayFabApiTest::PlayerStatisticsApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -371,7 +375,7 @@ namespace PlayFabUnit
             }
         }
 
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (actualStatValue == -1000)
         {
             testContext->Fail("Expected user statistic not found.");
@@ -386,9 +390,9 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Get or create the given test character for the given user
-    /// Parameter types tested: Contained-Classes, string
+    // CLIENT API
+    // Get or create the given test character for the given user
+    // Parameter types tested: Contained-Classes, string
     void PlayFabApiTest::UserCharacter(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -406,13 +410,13 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnUserCharacter(const ListUsersCharactersResult&, void* customData)
     {
         // We aren't adding a character to this account, so there's nothing really to test here
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test that leaderboard results can be requested
-    /// Parameter types tested: List of contained-classes
+    // CLIENT API
+    // Test that leaderboard results can be requested
+    // Parameter types tested: List of contained-classes
     void PlayFabApiTest::LeaderBoard(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -433,7 +437,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnClientLeaderBoard(const GetLeaderboardResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (result.Leaderboard.size() > 0) // We added too many users and stats to test for a specific user, so we just have to test for "any number of results" now
         {
             testContext->Pass();
@@ -444,9 +448,9 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that AccountInfo can be requested
-    /// Parameter types tested: List of enum-as-strings converted to list of enums
+    // CLIENT API
+    // Test that AccountInfo can be requested
+    // Parameter types tested: List of enum-as-strings converted to list of enums
     void PlayFabApiTest::AccountInfo(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -463,7 +467,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnAccountInfo(const GetAccountInfoResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         // Enums-by-name can't really be tested in C++, the way they can in other languages
         if (result.AccountInfo.isNull() || result.AccountInfo->TitleInfo.isNull() || result.AccountInfo->TitleInfo->Origination.isNull())
         {
@@ -475,8 +479,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that CloudScript can be properly set up and invoked
+    // CLIENT API
+    // Test that CloudScript can be properly set up and invoked
     void PlayFabApiTest::CloudScript(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -495,7 +499,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnHelloWorldCloudScript(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         std::string cloudScriptLogReport = "";
         if (result.Error.notNull())
         {
@@ -518,8 +522,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that a lambda success callback can be successfully invoked
+    // CLIENT API
+    // Test that a lambda success callback can be successfully invoked
     void PlayFabApiTest::CloudScriptLambda(TestContext& testContext)
     {
         ExecuteCloudScriptRequest hwRequest;
@@ -531,8 +535,8 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    /// CLIENT API
-    /// Test that CloudScript errors can be deciphered
+    // CLIENT API
+    // Test that CloudScript errors can be deciphered
     void PlayFabApiTest::CloudScriptError(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -551,7 +555,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnCloudScriptError(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         bool success = true;
         success &= result.FunctionResult.isNull();
         success &= result.Error.notNull();
@@ -566,8 +570,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that the client can publish custom PlayStream events
+    // CLIENT API
+    // Test that the client can publish custom PlayStream events
     void PlayFabApiTest::WriteEvent(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -589,12 +593,12 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnWritePlayerEvent(const WriteEventResponse&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// ENTITY API
-    /// Verify that a client login can be converted into an entity token
+    // ENTITY API
+    // Verify that a client login can be converted into an entity token
     void PlayFabApiTest::GetEntityToken(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -611,7 +615,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetEntityToken(const GetEntityTokenResponse& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
 
         entityId = result.Entity->Id;
         entityType = result.Entity->Type;
@@ -630,10 +634,10 @@ namespace PlayFabUnit
         }
     }
 
-    /// ENTITY API
-    /// Test a sequence of calls that modifies entity objects,
-    ///   and verifies that the next sequential API call contains updated information.
-    /// Verify that the object is correctly modified on the next call.
+    // ENTITY API
+    // Test a sequence of calls that modifies entity objects,
+    //   and verifies that the next sequential API call contains updated information.
+    // Verify that the object is correctly modified on the next call.
     void PlayFabApiTest::ObjectApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -690,7 +694,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetObjects2(const GetObjectsResponse& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
 
         int actualDataValue = -1000;
         auto found = result.Objects.find(TEST_DATA_KEY);
@@ -713,12 +717,11 @@ namespace PlayFabUnit
         }
     }
 
-    ///
-    ///
-    /// Add test calls to this method, after implementation
-    ///
-    ///
-
+    //
+    //
+    // Add test calls to this method, after implementation
+    //
+    //
     void PlayFabApiTest::AddTests()
     {
         AddTest("InvalidSettings", &PlayFabApiTest::InvalidSettings);
@@ -729,6 +732,7 @@ namespace PlayFabUnit
         AddTest("LoginWithAdvertisingId", &PlayFabApiTest::LoginWithAdvertisingId);
         AddTest("UserDataApi", &PlayFabApiTest::UserDataApi);
         AddTest("PlayerStatisticsApi", &PlayFabApiTest::PlayerStatisticsApi);
+        AddTest("GetServerTime", &PlayFabApiTest::GetServerTime);
         AddTest("UserCharacter", &PlayFabApiTest::UserCharacter);
         AddTest("LeaderBoard", &PlayFabApiTest::LeaderBoard);
         AddTest("AccountInfo", &PlayFabApiTest::AccountInfo);
@@ -749,7 +753,7 @@ namespace PlayFabUnit
         entityId = "";
         entityType = "";
         testMessageInt = 0;
-        testMessageTime = 0;
+        testMessageTime = PlayFab::GetPlayFabTimePointNow();
     }
 
     void PlayFabApiTest::SetUp(TestContext& testContext)

--- a/source/test/TestApp/PlayFabApiTest.h
+++ b/source/test/TestApp/PlayFabApiTest.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
+#include <playfab/PlayFabPlatformUtils.h>
+
 #include "TestCase.h"
 
 namespace PlayFab
@@ -42,140 +42,146 @@ namespace PlayFabUnit
 
     class PlayFabApiTest : public TestCase
     {
-        private:
-            // Fixed values provided from testInputs
-            bool TITLE_INFO_SET;
-            std::string USER_EMAIL;
+    private:
+        // Fixed values provided from testInputs
+        bool TITLE_INFO_SET;
+        std::string USER_EMAIL;
 
-            // Information fetched by appropriate API calls
-            const static std::string TEST_DATA_KEY;
-            const static std::string TEST_STAT_NAME;
-            std::string playFabId;
-            std::string entityId;
-            std::string entityType;
-            int testMessageInt;
-            time_t testMessageTime;
+        // Information fetched by appropriate API calls
+        const static std::string TEST_DATA_KEY;
+        const static std::string TEST_STAT_NAME;
+        std::string playFabId;
+        std::string entityId;
+        std::string entityType;
+        int testMessageInt;
+        PlayFab::TimePoint testMessageTime;
 
-            void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
+        void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Try to deliberately cause a client-side validation error
-            void InvalidSettings(TestContext& testContext);
+        // CLIENT API
+        // Try to deliberately cause a client-side validation error
+        void InvalidSettings(TestContext& testContext);
 
-            /// CLIENT API
-            /// Try to deliberately log in with an inappropriate password,
-            ///   and verify that the error displays as expected.
-            void InvalidLogin(TestContext& testContext);
-            void LoginCallback(const PlayFab::ClientModels::LoginResult&, void* customData);
-            void LoginFailedCallback(const PlayFab::PlayFabError& error, void* customData);
+        // CLIENT API
+        // Try to deliberately log in with an inappropriate password,
+        //   and verify that the error displays as expected.
+        void InvalidLogin(TestContext& testContext);
+        void LoginCallback(const PlayFab::ClientModels::LoginResult&, void* customData);
+        void LoginFailedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Test that a lambda error callback can be successfully invoked
-            void InvalidLoginLambda(TestContext& testContext);
+        // CLIENT API
+        // Test that a lambda error callback can be successfully invoked
+        void InvalidLoginLambda(TestContext& testContext);
 
-            /// CLIENT API
-            /// Try to deliberately register a user with an invalid email and password
-            ///   Verify that errorDetails are populated correctly.
-            void InvalidRegistration(TestContext& testContext);
-            void InvalidRegistrationSuccess(const PlayFab::ClientModels::RegisterPlayFabUserResult&, void* customData);
-            void InvalidRegistrationFail(const PlayFab::PlayFabError& error, void* customData);
+        // CLIENT API
+        // Try to deliberately register a user with an invalid email and password
+        //   Verify that errorDetails are populated correctly.
+        void InvalidRegistration(TestContext& testContext);
+        void InvalidRegistrationSuccess(const PlayFab::ClientModels::RegisterPlayFabUserResult&, void* customData);
+        void InvalidRegistrationFail(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Attempt a successful login
-            void LoginOrRegister(TestContext& testContext);
-            void OnLoginOrRegister(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        // CLIENT API
+        // Attempt a successful login
+        void LoginOrRegister(TestContext& testContext);
+        void OnLoginOrRegister(const PlayFab::ClientModels::LoginResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that the login call sequence sends the AdvertisingId when set
-            void LoginWithAdvertisingId(TestContext& testContext);
-            void OnLoginWithAdvertisingId(const PlayFab::ClientModels::LoginResult&, void* customData);
+        // CLIENT API
+        // Test that the login call sequence sends the AdvertisingId when set
+        void LoginWithAdvertisingId(TestContext& testContext);
+        void OnLoginWithAdvertisingId(const PlayFab::ClientModels::LoginResult&, void* customData);
 
-            /// CLIENT API
-            /// Test a sequence of calls that modifies saved data,
-            ///   and verifies that the next sequential API call contains updated data.
-            /// Verify that the data is correctly modified on the next call.
-            /// Parameter types tested: string, Dictionary<string, string>, DateTime
-            void UserDataApi(TestContext& testContext);
-            void OnUserDataApiGet1(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
-            void OnUserDataApiUpdate(const PlayFab::ClientModels::UpdateUserDataResult&, void* customData);
-            void OnUserDataApiGet2(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
+        // CLIENT API
+        // Test a sequence of calls that modifies saved data,
+        //   and verifies that the next sequential API call contains updated data.
+        // Verify that the data is correctly modified on the next call.
+        // Parameter types tested: string, Dictionary<string, string>, DateTime
+        void UserDataApi(TestContext& testContext);
+        void OnUserDataApiGet1(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
+        void OnUserDataApiUpdate(const PlayFab::ClientModels::UpdateUserDataResult&, void* customData);
+        void OnUserDataApiGet2(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test a sequence of calls that modifies saved data,
-            ///   and verifies that the next sequential API call contains updated data.
-            /// Verify that the data is saved correctly, and that specific types are tested
-            /// Parameter types tested: Dictionary<string, int>
-            void PlayerStatisticsApi(TestContext& testContext);
-            void OnPlayerStatisticsApiGet1(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
-            void OnPlayerStatisticsApiUpdate(const PlayFab::ClientModels::UpdatePlayerStatisticsResult&, void* customData);
-            void OnPlayerStatisticsApiGet2(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
+        // CLIENT API
+        // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
+        // Parameter types tested: DateTime
+        void GetServerTime(TestContext& testContext);
+        void OnGetServerTime(const PlayFab::ClientModels::GetTimeResult& result, void* customData);
 
-            /// CLIENT API
-            /// Get or create the given test character for the given user
-            /// Parameter types tested: Contained-Classes, string
-            void UserCharacter(TestContext& testContext);
-            void OnUserCharacter(const PlayFab::ClientModels::ListUsersCharactersResult&, void* customData);
+        // CLIENT API
+        // Test a sequence of calls that modifies saved data,
+        //   and verifies that the next sequential API call contains updated data.
+        // Verify that the data is saved correctly, and that specific types are tested
+        // Parameter types tested: Dictionary<string, int>
+        void PlayerStatisticsApi(TestContext& testContext);
+        void OnPlayerStatisticsApiGet1(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
+        void OnPlayerStatisticsApiUpdate(const PlayFab::ClientModels::UpdatePlayerStatisticsResult&, void* customData);
+        void OnPlayerStatisticsApiGet2(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that leaderboard results can be requested
-            /// Parameter types tested: List of contained-classes
-            void LeaderBoard(TestContext& testContext);
-            void OnClientLeaderBoard(const PlayFab::ClientModels::GetLeaderboardResult& result, void* customData);
+        // CLIENT API
+        // Get or create the given test character for the given user
+        // Parameter types tested: Contained-Classes, string
+        void UserCharacter(TestContext& testContext);
+        void OnUserCharacter(const PlayFab::ClientModels::ListUsersCharactersResult&, void* customData);
 
-            /// CLIENT API
-            /// Test that AccountInfo can be requested
-            /// Parameter types tested: List of enum-as-strings converted to list of enums
-            void AccountInfo(TestContext& testContext);
-            void OnAccountInfo(const PlayFab::ClientModels::GetAccountInfoResult& result, void* customData);
+        // CLIENT API
+        // Test that leaderboard results can be requested
+        // Parameter types tested: List of contained-classes
+        void LeaderBoard(TestContext& testContext);
+        void OnClientLeaderBoard(const PlayFab::ClientModels::GetLeaderboardResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that CloudScript can be properly set up and invoked
-            void CloudScript(TestContext& testContext);
-            void OnHelloWorldCloudScript(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
+        // CLIENT API
+        // Test that AccountInfo can be requested
+        // Parameter types tested: List of enum-as-strings converted to list of enums
+        void AccountInfo(TestContext& testContext);
+        void OnAccountInfo(const PlayFab::ClientModels::GetAccountInfoResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that a lambda success callback can be successfully invoked
-            void CloudScriptLambda(TestContext& testContext);
+        // CLIENT API
+        // Test that CloudScript can be properly set up and invoked
+        void CloudScript(TestContext& testContext);
+        void OnHelloWorldCloudScript(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that CloudScript errors can be deciphered
-            void CloudScriptError(TestContext& testContext);
-            void OnCloudScriptError(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
+        // CLIENT API
+        // Test that a lambda success callback can be successfully invoked
+        void CloudScriptLambda(TestContext& testContext);
 
-            /// CLIENT API
-            /// Test that the client can publish custom PlayStream events
-            void WriteEvent(TestContext& testContext);
-            void OnWritePlayerEvent(const PlayFab::ClientModels::WriteEventResponse&, void* customData);
+        // CLIENT API
+        // Test that CloudScript errors can be deciphered
+        void CloudScriptError(TestContext& testContext);
+        void OnCloudScriptError(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-            /// ENTITY API
-            /// Verify that a client login can be converted into an entity token
-            void GetEntityToken(TestContext& testContext);
-            void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void* customData);
+        // CLIENT API
+        // Test that the client can publish custom PlayStream events
+        void WriteEvent(TestContext& testContext);
+        void OnWritePlayerEvent(const PlayFab::ClientModels::WriteEventResponse&, void* customData);
 
-            /// ENTITY API
-            /// Test a sequence of calls that modifies entity objects,
-            ///   and verifies that the next sequential API call contains updated information.
-            /// Verify that the object is correctly modified on the next call.
-            void ObjectApi(TestContext& testContext);
-            void OnGetObjects1(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
-            void OnSetObjects(const PlayFab::DataModels::SetObjectsResponse&, void* customData);
-            void OnGetObjects2(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
+        // ENTITY API
+        // Verify that a client login can be converted into an entity token
+        void GetEntityToken(TestContext& testContext);
+        void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void* customData);
 
-            // Utility
-            template<typename T> std::function<void(const T&, void*)> Callback(void(PlayFabApiTest::*func)(const T&, void*))
-            {
-                return std::bind(func, this, std::placeholders::_1, std::placeholders::_2);
-            }
+        // ENTITY API
+        // Test a sequence of calls that modifies entity objects,
+        //   and verifies that the next sequential API call contains updated information.
+        // Verify that the object is correctly modified on the next call.
+        void ObjectApi(TestContext& testContext);
+        void OnGetObjects1(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
+        void OnSetObjects(const PlayFab::DataModels::SetObjectsResponse&, void* customData);
+        void OnGetObjects2(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
 
-        protected:
-            void AddTests() override;
+        // Utility
+        template<typename T> std::function<void(const T&, void*)> Callback(void(PlayFabApiTest::* func)(const T&, void*))
+        {
+            return std::bind(func, this, std::placeholders::_1, std::placeholders::_2);
+        }
 
-        public:
-            void SetTitleInfo(TestTitleData& testInputs);
+    protected:
+        void AddTests() override;
 
-            void ClassSetUp() override;
-            void SetUp(TestContext& /*testContext*/) override;
-            void Tick(TestContext& testContext) override;
-            void ClassTearDown() override;
+    public:
+        void SetTitleInfo(TestTitleData& testInputs);
+
+        void ClassSetUp() override;
+        void SetUp(TestContext& /*testContext*/) override;
+        void Tick(TestContext& testContext) override;
+        void ClassTearDown() override;
     };
 }

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -259,7 +259,7 @@ namespace PlayFabUnit
         // Sleep while waiting for log in to complete.
         while (!loginComplete)
         {
-            std::this_thread::sleep_for(TimeValueMs(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }
 

--- a/source/test/TestApp/TestApp.cpp
+++ b/source/test/TestApp/TestApp.cpp
@@ -69,7 +69,7 @@ namespace PlayFabUnit
 
         while (cloudResponse.empty())
         {
-            std::this_thread::sleep_for(TimeValueMs(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
         // Publish the test summary (including cloud script response) to STDOUT.

--- a/source/test/TestApp/TestAppPch.h
+++ b/source/test/TestApp/TestAppPch.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <playfab/PlayFabPlatformMacros.h>
+#include <playfab/PlayFabPlatformUtils.h>
+#include <playfab/PlayFabAuthenticationContext.h>
 
 #if defined (_XBOX_ONE)
 

--- a/source/test/TestApp/TestContext.cpp
+++ b/source/test/TestApp/TestContext.cpp
@@ -10,7 +10,7 @@ namespace PlayFabUnit
     {
         if (finishState == TestFinishState::PENDING) // This means that we finish successfully
         {
-            endTime = TestTimeNow();
+            endTime = PlayFab::GetPlayFabTimePointNow();
             testResultMsg = resultMsg;
             finishState = state;
             activeState = TestActiveState::READY;

--- a/source/test/TestApp/TestContext.h
+++ b/source/test/TestApp/TestContext.h
@@ -4,7 +4,10 @@
 
 #include <functional>
 #include <string>
+
 #include "TestDataTypes.h"
+
+#include <playfab/PlayFabPlatformUtils.h>
 
 namespace PlayFabUnit
 {
@@ -30,8 +33,8 @@ namespace PlayFabUnit
         std::string testResultMsg;
         TestFunc testFunc;
         TestCase* testCase;
-        TimePoint startTime;
-        TimePoint endTime;
+        PlayFab::TimePoint startTime;
+        PlayFab::TimePoint endTime;
 
         void EndTest(TestFinishState state, std::string resultMsg);
 

--- a/source/test/TestApp/TestDataTypes.h
+++ b/source/test/TestApp/TestDataTypes.h
@@ -31,7 +31,4 @@ namespace PlayFabUnit
         SKIPPED,
         TIMEDOUT
     };
-
-    typedef std::chrono::time_point<std::chrono::system_clock> TimePoint;
-    typedef std::chrono::milliseconds TimeValueMs;
 }

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -2,7 +2,9 @@
 #include <memory>
 
 #include "TestAppPch.h"
+
 #include <playfab/PlayFabJsonHeaders.h>
+
 #include "TestReport.h"
 #include "TestUtils.h"
 
@@ -26,12 +28,7 @@ namespace PlayFabUnit
         json["errors"] = errors;
         json["skipped"] = skipped;
         json["time"] = time;
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_SWITCH)
-        json["timestamp"] = static_cast<Json::Int64>(std::chrono::system_clock::to_time_t(timeStamp));
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH
-        json["timestamp"] = std::chrono::system_clock::to_time_t(timeStamp);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH
-
+        json["timestamp"] = PlayFab::LocalTimePointToUtcString(timeStamp);
         json["testResults"];
         Json::Value init(Json::arrayValue);
         json["testResults"].swapPayload(init);
@@ -47,7 +44,7 @@ namespace PlayFabUnit
     TestReport::TestReport(std::string className)
     {
         internalReport.name = className;
-        internalReport.timeStamp = TestTimeNow();
+        internalReport.timeStamp = PlayFab::GetPlayFabTimePointNow();
         internalReport.tests = 0;
         internalReport.failures = 0;
         internalReport.errors = 0;
@@ -60,7 +57,7 @@ namespace PlayFabUnit
         internalReport.tests += 1;
     }
 
-    void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, TimeValueMs testDurationMs, std::string message)
+    void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message)
     {
         // Add a new TestCaseReport for the completed test.
         TestCaseReport* testReport = new TestCaseReport();
@@ -78,20 +75,20 @@ namespace PlayFabUnit
         // Update statistics.
         switch (testFinishState)
         {
-            case TestFinishState::PASSED: internalReport.passed += 1; break;
-            case TestFinishState::FAILED: internalReport.failures += 1; break;
-            case TestFinishState::SKIPPED: internalReport.skipped += 1; break;
-            case TestFinishState::PENDING:
-                break;
-            case TestFinishState::TIMEDOUT: 
-                break;
-            default:
-                break;
+        case TestFinishState::PASSED: internalReport.passed += 1; break;
+        case TestFinishState::FAILED: internalReport.failures += 1; break;
+        case TestFinishState::SKIPPED: internalReport.skipped += 1; break;
+        case TestFinishState::PENDING:
+            break;
+        case TestFinishState::TIMEDOUT:
+            break;
+        default:
+            break;
         }
 
         // Update overall runtime.
         // TODO: Add hooks for SuiteSetUp and SuiteTearDown, so this can be estimated more accurately
-        internalReport.time = std::chrono::duration<double>(TestTimeNow() - internalReport.timeStamp).count(); // For now, update the duration on every test complete - the last one will be essentially correct
+        internalReport.time = std::chrono::duration<double>(PlayFab::GetPlayFabTimePointNow() - internalReport.timeStamp).count(); // For now, update the duration on every test complete - the last one will be essentially correct
     }
 
     bool TestReport::AllTestsPassed()

--- a/source/test/TestApp/TestReport.h
+++ b/source/test/TestApp/TestReport.h
@@ -44,7 +44,7 @@ namespace PlayFabUnit
             int errors; // count tests in state
             int skipped; // count tests in state
             double time; // Duration in seconds
-            TimePoint timeStamp;
+            PlayFab::TimePoint timeStamp;
             // Useful for debugging but not part of the serialized format
             int passed; // Could be calculated from the others, but sometimes knowing if they don't add up means something
             std::list<std::shared_ptr<TestCaseReport*>> testResults;
@@ -61,7 +61,7 @@ namespace PlayFabUnit
 
             void TestStarted();
 
-            void TestComplete(std::string testName, TestFinishState testFinishState, TimeValueMs testDurationMs, std::string message);
+            void TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message);
 
             bool AllTestsPassed();
     };

--- a/source/test/TestApp/TestUtils.cpp
+++ b/source/test/TestApp/TestUtils.cpp
@@ -30,9 +30,4 @@ namespace PlayFabUnit
             default: return "UNKNOWN";
         }
     }
-
-    TimePoint TestTimeNow()
-    {
-        return std::chrono::system_clock::now();
-    }
 }

--- a/source/test/TestApp/TestUtils.h
+++ b/source/test/TestApp/TestUtils.h
@@ -8,11 +8,4 @@ namespace PlayFabUnit
 {
     const char* ToString(TestActiveState state);
     const char* ToString(TestFinishState state);
-
-    TimePoint TestTimeNow();
-
-    template<class T> T TestTimeDelta(TimePoint earlier, TimePoint later)
-    {
-        return std::chrono::duration_cast<T>(later - earlier);
-    }
 }

--- a/templates/PlayFab_InstanceAPI.h.ejs
+++ b/templates/PlayFab_InstanceAPI.h.ejs
@@ -4,7 +4,6 @@
 
 #include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFabApiSettings.h>
-#include <playfab/PlayFabAuthenticationContext.h>
 #include <playfab/PlayFab<%- api.name %>DataModels.h>
 #include <memory>
 


### PR DESCRIPTION
All other files cross reference this file, and it's generic interface
A few header cleanups and improvements that were close to this change - Particularly about being #defined against platforms
Converting several non-customer facing time calculations to use std::chrono

Repo changes applied by these template changes viewable here:
https://github.com/PlayFab/XPlatCppSdk/pull/32