### PR TITLE
Exes and static libraries can now agree on the size of PlayFabApiSettings and PlayFabAuthenticationContext

### DIFF
--- a/make.js
+++ b/make.js
@@ -7,12 +7,16 @@ if (typeof templatizeTree === "undefined") templatizeTree = function () { };
 exports.makeCombinedAPI = function (apis, sourceDir, apiOutputDir) {
     console.log("Generating Combined api from: " + sourceDir + " to: " + apiOutputDir);
 
-    var extraDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;";
+    var libDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;";
+    var clientDefines = "";
+    var serverDefines = "ENABLE_PLAYFABADMIN_API;ENABLE_PLAYFABSERVER_API;DISABLE_PLAYFABCLIENT_API;";
 
     var locals = {
         apis: apis,
         buildIdentifier: sdkGlobals.buildIdentifier,
-        extraDefines: extraDefines,
+        clientDefines: clientDefines,
+        libDefines: libDefines,
+        serverDefines: serverDefines,
         sdkVersion: sdkGlobals.sdkVersion,
         sdkDate: sdkGlobals.sdkVersion.split(".")[2],
         sdkYear: sdkGlobals.sdkVersion.split(".")[2].substr(0, 2),
@@ -245,14 +249,17 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
 
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "std::string authKey, authValue;\n" +
-            tabbing + "if (context->entityToken.length() > 0) {\n" +
+            tabbing + "if (context->entityToken.length() > 0)\n" +
+            tabbing + "{\n" +
             tabbing + "    authKey = \"X-EntityToken\"; authValue = context->entityToken;\n" +
             tabbing + "}\n" +
-            tabbing + "else if (context->clientSessionTicket.length() > 0) {\n" +
+            tabbing + "else if (context->clientSessionTicket.length() > 0)\n" +
+            tabbing + "{\n" +
             tabbing + "    authKey = \"X-Authorization\"; authValue = context->clientSessionTicket;\n" +
             tabbing + "}\n" +
             "#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)\n" +
-            tabbing + "else if (settings->developerSecretKey.length() > 0) {\n" +
+            tabbing + "else if (settings->developerSecretKey.length() > 0)\n" +
+            tabbing + "{\n" +
             tabbing + "    authKey = \"X-SecretKey\"; authValue = settings->developerSecretKey;\n" +
             tabbing + "}\n" +
             "#endif\n";

--- a/source/build/Windows/MainWin32.cpp
+++ b/source/build/Windows/MainWin32.cpp
@@ -3,11 +3,56 @@
 #include "TestAppPch.h"
 #include "TestApp.h"
 
+#include <playfab/PlayFabApiSettings.h>
+#include <playfab/PlayFabAuthenticationContext.h>
+
 // Win32 Entry Point
 int main()
 {
-    PlayFabUnit::TestApp testApp;
+    // Settings
+    PlayFab::PlayFabApiSettings* testPtrSettings = new PlayFab::PlayFabApiSettings();
+    testPtrSettings->titleId = "this should succeed";
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+    testPtrSettings->developerSecretKey = "this is conditional";
+#endif
+    delete testPtrSettings;
 
-    int result = testApp.Main();
-    return result;
+    std::shared_ptr<PlayFab::PlayFabApiSettings> testMSpSettings = std::make_shared<PlayFab::PlayFabApiSettings>();
+    testMSpSettings->titleId = "this should succeed";
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+    testMSpSettings->developerSecretKey = "this is conditional";
+#endif
+    testMSpSettings.reset();
+
+    std::shared_ptr<PlayFab::PlayFabApiSettings> testNSpSettings = std::shared_ptr<PlayFab::PlayFabApiSettings>(new PlayFab::PlayFabApiSettings());
+    testNSpSettings->titleId = "this should succeed";
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+    testNSpSettings->developerSecretKey = "this is conditional";
+#endif
+    testNSpSettings.reset();
+
+    // Context
+    PlayFab::PlayFabAuthenticationContext* testPtrContext = new PlayFab::PlayFabAuthenticationContext();
+    testPtrContext->entityId = "this should succeed";
+#ifndef DISABLE_PLAYFABCLIENT_API
+    testPtrContext->playFabId = "this is conditional";
+#endif
+    delete testPtrContext;
+
+    std::shared_ptr<PlayFab::PlayFabAuthenticationContext> testMSPContext = std::make_shared<PlayFab::PlayFabAuthenticationContext>();
+    testMSPContext->entityId = "this should succeed";
+#ifndef DISABLE_PLAYFABCLIENT_API
+    testMSPContext->playFabId = "this is conditional";
+#endif
+    testMSPContext.reset();
+
+    std::shared_ptr<PlayFab::PlayFabAuthenticationContext> testNSpContext = std::shared_ptr<PlayFab::PlayFabAuthenticationContext>(new PlayFab::PlayFabAuthenticationContext());
+    testNSpContext->entityId = "this should succeed";
+#ifndef DISABLE_PLAYFABCLIENT_API
+    testNSpContext->playFabId = "this is conditional";
+#endif
+    testNSpContext.reset();
+
+    PlayFabUnit::TestApp testApp;
+    return testApp.Main();
 }

--- a/source/build/Windows/TestClientApp.vcxproj.ejs
+++ b/source/build/Windows/TestClientApp.vcxproj.ejs
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <Import Project="SetDirectoryPaths.props" />
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{3E4DF9A7-08A4-4188-9C86-B60605F3710B}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>TestApp</RootNamespace>
+    <ProjectName>TestClientApp</ProjectName>
+    <OutputSubDir>TestApp</OutputSubDir>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(OutputSubDir)\</OutDir>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset><%- vsVer %></PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset><%- vsVer %></PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <IncludePath>$(IncludePath)</IncludePath>
+    <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32;<%- clientDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(TestSourceDir)\TestApp;$(SdkSourceDir)\include;$(ExternalDir)\jsoncpp\include</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile>TestAppPch.h</PrecompiledHeaderFile>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MinimalRebuild>false</MinimalRebuild>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>XPlatCppWindows.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\XPlatCppWindows</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>Use</PrecompiledHeader>
+      <WarningLevel>Level4</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;WIN32;<%- clientDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(TestSourceDir)\TestApp;$(SdkSourceDir)\include;$(ExternalDir)\jsoncpp\include</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile>TestAppPch.h</PrecompiledHeaderFile>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <TreatWarningAsError>true</TreatWarningAsError>
+      <MinimalRebuild>false</MinimalRebuild>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <AdditionalOptions>/Zc:__cplusplus /bigobj %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>XPlatCppWindows.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(SolutionDir)$(Platform)\$(Configuration)\XPlatCppWindows</AdditionalLibraryDirectories>
+      <AdditionalOptions>/ignore:4099 %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestAppPch.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabApiTest.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabEventTest.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserInstance.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserStatic.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestApp.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestCase.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestContext.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestDataTypes.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestReport.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestRunner.h" />
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestUtils.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestApp.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestAppPch.cpp">
+      <PrecompiledHeader>Create</PrecompiledHeader>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabApiTest.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabEventTest.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserInstance.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserStatic.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestContext.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestReport.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestRunner.cpp" />
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestUtils.cpp" />
+    <ClCompile Include="MainWin32.cpp" />
+    <ClCompile Include="TestAppWin32.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="XPlatCppWindows.vcxproj">
+      <Project>{92f6ec5f-b66c-4572-a74d-79329aff3129}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <Target Name="CopyDependencies" AfterTargets="AfterBuild">
+    <ItemGroup>
+      <Dependency Include="$(TFS_BinariesDirectory)\$(Configuration)\$(Platform)\XPlatCppWindows\*.dll" />
+      <Dependency Include="$(SolutionDir)$(Platform)\$(Configuration)\XPlatCppWindows\*.dll" />
+    </ItemGroup>
+    <Copy SourceFiles="@(Dependency)" DestinationFolder="$(OutDir)" SkipUnchangedFiles="true" />
+  </Target>
+</Project>

--- a/source/build/Windows/TestClientApp.vcxproj.filters
+++ b/source/build/Windows/TestClientApp.vcxproj.filters
@@ -51,6 +51,12 @@
     <ClInclude Include="$(TestSourceDir)\TestApp\TestApp.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(TestSourceDir)\TestApp\TestApp.cpp">

--- a/source/build/Windows/TestServerApp.vcxproj.ejs
+++ b/source/build/Windows/TestServerApp.vcxproj.ejs
@@ -13,10 +13,10 @@
   <Import Project="SetDirectoryPaths.props" />
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
-    <ProjectGuid>{3E4DF9A7-08A4-4188-9C86-B60605F3710B}</ProjectGuid>
+    <ProjectGuid>{C60B7622-A3C7-4109-AB39-399662D4FA87}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>TestApp</RootNamespace>
-    <ProjectName>TestApp</ProjectName>
+    <ProjectName>TestServerApp</ProjectName>
     <OutputSubDir>TestApp</OutputSubDir>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(OutputSubDir)\</OutDir>
   </PropertyGroup>
@@ -61,7 +61,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;WIN32;<%- serverDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(TestSourceDir)\TestApp;$(SdkSourceDir)\include;$(ExternalDir)\jsoncpp\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>TestAppPch.h</PrecompiledHeaderFile>
@@ -85,7 +85,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_CONSOLE;WIN32;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CONSOLE;WIN32;<%- serverDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(TestSourceDir)\TestApp;$(SdkSourceDir)\include;$(ExternalDir)\jsoncpp\include</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>TestAppPch.h</PrecompiledHeaderFile>
@@ -117,6 +117,8 @@
     <ClInclude Include="$(TestSourceDir)\TestApp\TestReport.h" />
     <ClInclude Include="$(TestSourceDir)\TestApp\TestRunner.h" />
     <ClInclude Include="$(TestSourceDir)\TestApp\TestUtils.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h" />
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="$(TestSourceDir)\TestApp\TestApp.cpp" />
@@ -132,7 +134,7 @@
     <ClCompile Include="$(TestSourceDir)\TestApp\TestRunner.cpp" />
     <ClCompile Include="$(TestSourceDir)\TestApp\TestUtils.cpp" />
     <ClCompile Include="MainWin32.cpp" />
-	<ClCompile Include="TestAppWin32.cpp" />
+    <ClCompile Include="TestAppWin32.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="XPlatCppWindows.vcxproj">

--- a/source/build/Windows/TestServerApp.vcxproj.filters
+++ b/source/build/Windows/TestServerApp.vcxproj.filters
@@ -1,0 +1,99 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestAppPch.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabApiTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabEventTest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserInstance.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserStatic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestCase.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestContext.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestDataTypes.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestReport.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestRunner.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestUtils.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(TestSourceDir)\TestApp\TestApp.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabAuthenticationContext.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+    <ClInclude Include="$(SdkSourceDir)\include\playfab\PlayFabApiSettings.h">
+      <Filter>Header Files\playfab</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestAppPch.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabApiTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabEventTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserInstance.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\PlayFabTestMultiUserStatic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestContext.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestReport.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestRunner.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(TestSourceDir)\TestApp\TestUtils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="MainWin32.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="TestAppWin32.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/source/build/Windows/XPlatCppWindows.sln.ejs
+++ b/source/build/Windows/XPlatCppWindows.sln.ejs
@@ -4,7 +4,7 @@ VisualStudioVersion = 15.0.27130.2036
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "XPlatCppWindows", "XPlatCppWindows.vcxproj", "{92F6EC5F-B66C-4572-A74D-79329AFF3129}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestApp", "TestApp.vcxproj", "{3E4DF9A7-08A4-4188-9C86-B60605F3710B}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestClientApp", "TestClientApp.vcxproj", "{3E4DF9A7-08A4-4188-9C86-B60605F3710B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertySheets", "{DDB43465-C46F-4041-9AC4-687E42680072}"
 	ProjectSection(SolutionItems) = preProject
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PropertySheets", "PropertyS
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "lib_json", "..\..\external\jsoncpp-build\lib_json.vcxproj", "{1E6C2C1C-6453-4129-AE3F-0EE8E6599C89}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "TestServerApp", "TestServerApp.vcxproj", "{C60B7622-A3C7-4109-AB39-399662D4FA87}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +33,10 @@ Global
 		{1E6C2C1C-6453-4129-AE3F-0EE8E6599C89}.Debug|x64.Build.0 = Debug|x64
 		{1E6C2C1C-6453-4129-AE3F-0EE8E6599C89}.Release|x64.ActiveCfg = Release|x64
 		{1E6C2C1C-6453-4129-AE3F-0EE8E6599C89}.Release|x64.Build.0 = Release|x64
+		{C60B7622-A3C7-4109-AB39-399662D4FA87}.Debug|x64.ActiveCfg = Debug|x64
+		{C60B7622-A3C7-4109-AB39-399662D4FA87}.Debug|x64.Build.0 = Debug|x64
+		{C60B7622-A3C7-4109-AB39-399662D4FA87}.Release|x64.ActiveCfg = Release|x64
+		{C60B7622-A3C7-4109-AB39-399662D4FA87}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/build/Windows/XPlatCppWindows.vcxproj.ejs
+++ b/source/build/Windows/XPlatCppWindows.vcxproj.ejs
@@ -61,7 +61,7 @@
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;<%- libDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SdkSourceDir);$(ExternalDir)/jsoncpp/include;$(SdkSourceDir)/include</AdditionalIncludeDirectories>
@@ -87,7 +87,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_LIB;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_LIB;<%- libDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(SdkSourceDir);$(ExternalDir)/jsoncpp/include;$(SdkSourceDir)/include</AdditionalIncludeDirectories>

--- a/source/build/Xbox/XPlatXbox.vcxproj.ejs
+++ b/source/build/Xbox/XPlatXbox.vcxproj.ejs
@@ -102,7 +102,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalUsingDirectories>$(Console_SdkPackagesRoot);$(Console_SdkWindowsMetadataPath);%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <Optimization>MaxSpeed</Optimization>
-      <PreprocessorDefinitions>NDEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;<%- libDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -131,7 +131,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <AdditionalUsingDirectories>$(Console_SdkPackagesRoot);$(Console_SdkWindowsMetadataPath);%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <Optimization>MaxSpeed</Optimization>
-      <PreprocessorDefinitions>NDEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;PROFILE;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;PROFILE;<%- libDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -158,7 +158,7 @@
       <AdditionalUsingDirectories>$(Console_SdkPackagesRoot);$(Console_SdkWindowsMetadataPath);%(AdditionalUsingDirectories)</AdditionalUsingDirectories>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;<%- extraDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;__WRL_NO_DEFAULT_LIB__;_LIB;<%- libDefines %>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <CompileAsWinRT>false</CompileAsWinRT>
       <AdditionalIncludeDirectories>$(SdkSourceDir);$(ExternalDir)/jsoncpp/include;$(SdkSourceDir)/include</AdditionalIncludeDirectories>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>

--- a/source/code/include/playfab/PlayFabApiSettings.h
+++ b/source/code/include/playfab/PlayFabApiSettings.h
@@ -10,14 +10,18 @@ namespace PlayFab
     /// </summary>
     class PlayFabApiSettings
     {
+#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
+    public: // Server-only variables should only be visible when appropriate
+#else
+    private: // But, static library memory size and alloc issues mean it always needs to exist
+#endif
+        std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
+
     public:
         static const std::map<std::string, std::string> requestGetParams;
 
         std::string baseServiceHost; // The base for a PlayFab service host
         std::string titleId; // You must set this value for PlayFabSdk to work properly (found in the Game Manager for your title, at the PlayFab Website)
-#if defined(ENABLE_PLAYFABSERVER_API) || defined(ENABLE_PLAYFABADMIN_API)
-        std::string developerSecretKey; // Developer secret key. These keys can be used in development environments.
-#endif
 
         PlayFabApiSettings();
         PlayFabApiSettings(const PlayFabApiSettings& other) = delete;

--- a/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -9,8 +9,11 @@ namespace PlayFab
     /// </summary>
     class PlayFabAuthenticationContext
     {
-    public:
 #ifndef DISABLE_PLAYFABCLIENT_API
+    public: // Client-only variables should only be visible when appropriate
+#else
+    private: // But, static library memory size and alloc issues mean it always needs to exist
+#endif
         // DisableAdvertising is provided for completeness, but changing it is not suggested
         // Disabling this may prevent your advertising-related PlayFab marketplace partners from working correctly
         bool disableAdvertising;
@@ -18,7 +21,8 @@ namespace PlayFab
         std::string clientSessionTicket; // Client session ticket that is used as an authentication token in many PlayFab API methods.
         std::string advertisingIdType; // Set this to the appropriate AD_TYPE_X constant below
         std::string advertisingIdValue; // Set this to corresponding device value
-#endif
+
+    public:
         std::string entityId; // Entity Id for the active entity
         std::string entityType; // Entity Type for the active entity
         std::string entityToken; // User's entity token. Entity tokens are required by all Entity API methods.

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -4,20 +4,18 @@
 
 #ifndef DISABLE_PLAYFABCLIENT_API
 
-#include <chrono>
-
-#include <playfab/PlayFabApiSettings.h>
-#include <playfab/PlayFabSettings.h>
-
-#include <playfab/PlayFabAuthenticationApi.h>
-#include <playfab/PlayFabAuthenticationDataModels.h>
+#include <string>
 #include <playfab/PlayFabClientApi.h>
+#include <playfab/PlayFabSettings.h>
+#include <playfab/PlayFabAuthenticationDataModels.h>
+#include <playfab/PlayFabAuthenticationApi.h>
 #include <playfab/PlayFabClientDataModels.h>
-#include <playfab/PlayFabDataApi.h>
 #include <playfab/PlayFabDataDataModels.h>
-
+#include <playfab/PlayFabDataApi.h>
+#include <playfab/PlayFabPlatformMacros.h>
 #include "PlayFabApiTest.h"
 #include "TestContext.h"
+
 
 using namespace PlayFab;
 using namespace ClientModels;
@@ -40,12 +38,12 @@ namespace PlayFabUnit
 
     void PlayFabApiTest::OnErrorSharedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Fail("Unexpected error: " + error.ErrorMessage);
     }
 
-    // CLIENT API
-    // Try to deliberately cause a client-side validation error
+    /// CLIENT API
+    /// Try to deliberately cause a client-side validation error
     void PlayFabApiTest::InvalidSettings(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -62,13 +60,13 @@ namespace PlayFabUnit
             [&validTitleId](const LoginResult&, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = static_cast<TestContext*>(customData);
+            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
             testContext->Fail("Expected API call to fail on the client side");
         },
             [&validTitleId](const PlayFabError& error, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = static_cast<TestContext*>(customData);
+            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
             if (error.HttpCode == 0
                 && error.HttpStatus == "Client-side validation failure"
                 && error.ErrorCode == PlayFabErrorCode::PlayFabErrorInvalidParams
@@ -80,9 +78,9 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    // CLIENT API
-    // Try to deliberately log in with an inappropriate password,
-    //   and verify that the error displays as expected.
+    /// CLIENT API
+    /// Try to deliberately log in with an inappropriate password,
+    ///   and verify that the error displays as expected.
     void PlayFabApiTest::InvalidLogin(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -96,28 +94,31 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::LoginCallback(const LoginResult&, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Fail("Expected login to fail");
     }
     void PlayFabApiTest::LoginFailedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
         if (error.RequestId.empty())
         {
             testContext->Fail("The requestId should be set on a failure.");
         }
-        else if (error.ErrorMessage.find("password") != -1)
-        {
-            testContext->Pass(error.RequestId);
-        }
         else
-        {
-            testContext->Fail("Password error message not found: " + error.ErrorMessage);
-        }
+#endif // defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
+            if (error.ErrorMessage.find("password") != -1)
+            {
+                testContext->Pass(error.RequestId);
+            }
+            else
+            {
+                testContext->Fail("Password error message not found: " + error.ErrorMessage);
+            }
     }
 
-    // CLIENT API
-    // Test that a lambda error callback can be successfully invoked
+    /// CLIENT API
+    /// Test that a lambda error callback can be successfully invoked
     void PlayFabApiTest::InvalidLoginLambda(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -126,13 +127,13 @@ namespace PlayFabUnit
 
         PlayFabClientAPI::LoginWithEmailAddress(request,
             nullptr,
-            [](const PlayFabError& error, void* customData) { TestContext* testContext = static_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
+            [](const PlayFabError& error, void* customData) { TestContext* testContext = reinterpret_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
             &testContext);
     }
 
-    // CLIENT API
-    // Try to deliberately register a user with an invalid email and password
-    //   Verify that errorDetails are populated correctly.
+    /// CLIENT API
+    /// Try to deliberately register a user with an invalid email and password
+    ///   Verify that errorDetails are populated correctly.
     void PlayFabApiTest::InvalidRegistration(TestContext& testContext)
     {
         RegisterPlayFabUserRequest request;
@@ -147,7 +148,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::InvalidRegistrationSuccess(const RegisterPlayFabUserResult&, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Fail("Expected registration to fail");
     }
     void PlayFabApiTest::InvalidRegistrationFail(const PlayFabError& error, void* customData)
@@ -160,7 +161,7 @@ namespace PlayFabUnit
         foundEmailMsg = (errorReport.find(expectedEmailMsg) != -1);
         foundPasswordMsg = (errorReport.find(expectedPasswordMsg) != -1);
 
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         if (foundEmailMsg && foundPasswordMsg)
         {
             testContext->Pass();
@@ -171,8 +172,8 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Attempt a successful login
+    /// CLIENT API
+    /// Attempt a successful login
     void PlayFabApiTest::LoginOrRegister(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -187,12 +188,12 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginOrRegister(const LoginResult& result, void* customData)
     {
         playFabId = result.PlayFabId;
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    // CLIENT API
-    // Test that the login call sequence sends the AdvertisingId when set
+    /// CLIENT API
+    /// Test that the login call sequence sends the AdvertisingId when set
     void PlayFabApiTest::LoginWithAdvertisingId(TestContext& testContext)
     {
         PlayFabSettings::staticPlayer->advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
@@ -211,15 +212,15 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginWithAdvertisingId(const LoginResult&, void* customData)
     {
         // TODO: Need to wait for the NEXT api call to complete, and then test PlayFabSettings::staticPlayer->advertisingIdType
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    // CLIENT API
-    // Test a sequence of calls that modifies saved data,
-    //   and verifies that the next sequential API call contains updated data.
-    // Verify that the data is correctly modified on the next call.
-    // Parameter types tested: string, Dictionary<string, string>
+    /// CLIENT API
+    /// Test a sequence of calls that modifies saved data,
+    ///   and verifies that the next sequential API call contains updated data.
+    /// Verify that the data is correctly modified on the next call.
+    /// Parameter types tested: string, Dictionary<string, string>, DateTime
     void PlayFabApiTest::UserDataApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -243,8 +244,15 @@ namespace PlayFabUnit
         testMessageInt = (testMessageInt + 1) % 100;
         UpdateUserDataRequest updateRequest;
 
+        // itoa is not avaialable in android
+        char buffer[16];
         std::string temp;
-        AppendIntToString(testMessageInt, temp);
+#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
+        sprintf(buffer, "%d", testMessageInt);
+#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
+        sprintf_s(buffer, "%d", testMessageInt);
+#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
+        temp.append(buffer);
 
         updateRequest.Data[TEST_DATA_KEY] = temp;
         PlayFabClientAPI::UpdateUserData(updateRequest,
@@ -264,8 +272,23 @@ namespace PlayFabUnit
     {
         auto it = result.Data.find(TEST_DATA_KEY);
         int actualDataValue = (it == result.Data.end()) ? -1 : atoi(it->second.Value.c_str());
+        testMessageTime = (it == result.Data.end()) ? 0 : it->second.LastUpdated;
 
-        TestContext* testContext = static_cast<TestContext*>(customData);
+#if !defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        time_t now = time(nullptr);
+        struct tm timeinfo;
+#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
+        timeinfo = *gmtime(&now);
+        now = timegm(&timeinfo);
+#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
+        gmtime_s(&timeinfo, &now);
+        now = _mkgmtime(&timeinfo);
+#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
+        time_t minTime = now - (60 * 5);
+        time_t maxTime = now + (60 * 5);
+#endif // PLAYFAB_PLATFORM_PLAYSTATION
+
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         if (it == result.Data.end())
         {
             testContext->Fail("Expected user data not found.");
@@ -274,49 +297,23 @@ namespace PlayFabUnit
         {
             testContext->Fail("User data not updated as expected.");
         }
+#if !defined(PLAYFAB_PLATFORM_PLAYSTATION) // Issue 32699
+        else if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
+        {
+            testContext->Fail("DateTime not parsed correctly..");
+        }
+#endif // PLAYFAB_PLATFORM_PLAYSTATION
         else
         {
             testContext->Pass();
         }
     }
 
-    // CLIENT API
-    // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
-    // Parameter types tested: DateTime
-    void PlayFabApiTest::GetServerTime(TestContext& testContext)
-    {
-        if (!PlayFabClientAPI::IsClientLoggedIn())
-        {
-            testContext.Skip("Earlier tests failed to log in");
-            return;
-        }
-
-        GetTimeRequest request;
-        PlayFabClientAPI::GetTime(request,
-            Callback(&PlayFabApiTest::OnGetServerTime),
-            Callback(&PlayFabApiTest::OnErrorSharedCallback),
-            &testContext);
-    }
-    void PlayFabApiTest::OnGetServerTime(const GetTimeResult& result, void* customData)
-    {
-        testMessageTime = std::chrono::system_clock::from_time_t(result.Time);
-
-        TimePoint now = GetPlayFabTimePointNow();
-        TimePoint minTime = now - std::chrono::minutes(5);
-        TimePoint maxTime = now + std::chrono::minutes(5);
-
-        TestContext* testContext = static_cast<TestContext*>(customData);
-        if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
-            testContext->Fail("DateTime not parsed correctly.");
-        else
-            testContext->Pass();
-    }
-
-    // CLIENT API
-    // Test a sequence of calls that modifies saved data,
-    //   and verifies that the next sequential API call contains updated data.
-    // Verify that the data is saved correctly, and that specific types are tested
-    // Parameter types tested: Dictionary<string, int>
+    /// CLIENT API
+    /// Test a sequence of calls that modifies saved data,
+    ///   and verifies that the next sequential API call contains updated data.
+    /// Verify that the data is saved correctly, and that specific types are tested
+    /// Parameter types tested: Dictionary<string, int>
     void PlayFabApiTest::PlayerStatisticsApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -377,7 +374,7 @@ namespace PlayFabUnit
             }
         }
 
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         if (actualStatValue == -1000)
         {
             testContext->Fail("Expected user statistic not found.");
@@ -392,9 +389,9 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Get or create the given test character for the given user
-    // Parameter types tested: Contained-Classes, string
+    /// CLIENT API
+    /// Get or create the given test character for the given user
+    /// Parameter types tested: Contained-Classes, string
     void PlayFabApiTest::UserCharacter(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -412,13 +409,13 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnUserCharacter(const ListUsersCharactersResult&, void* customData)
     {
         // We aren't adding a character to this account, so there's nothing really to test here
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    // CLIENT API
-    // Test that leaderboard results can be requested
-    // Parameter types tested: List of contained-classes
+    /// CLIENT API
+    /// Test that leaderboard results can be requested
+    /// Parameter types tested: List of contained-classes
     void PlayFabApiTest::LeaderBoard(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -439,7 +436,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnClientLeaderBoard(const GetLeaderboardResult& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         if (result.Leaderboard.size() > 0) // We added too many users and stats to test for a specific user, so we just have to test for "any number of results" now
         {
             testContext->Pass();
@@ -450,9 +447,9 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Test that AccountInfo can be requested
-    // Parameter types tested: List of enum-as-strings converted to list of enums
+    /// CLIENT API
+    /// Test that AccountInfo can be requested
+    /// Parameter types tested: List of enum-as-strings converted to list of enums
     void PlayFabApiTest::AccountInfo(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -469,7 +466,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnAccountInfo(const GetAccountInfoResult& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         // Enums-by-name can't really be tested in C++, the way they can in other languages
         if (result.AccountInfo.isNull() || result.AccountInfo->TitleInfo.isNull() || result.AccountInfo->TitleInfo->Origination.isNull())
         {
@@ -481,8 +478,8 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Test that CloudScript can be properly set up and invoked
+    /// CLIENT API
+    /// Test that CloudScript can be properly set up and invoked
     void PlayFabApiTest::CloudScript(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -501,7 +498,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnHelloWorldCloudScript(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         std::string cloudScriptLogReport = "";
         if (result.Error.notNull())
         {
@@ -524,8 +521,8 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Test that a lambda success callback can be successfully invoked
+    /// CLIENT API
+    /// Test that a lambda success callback can be successfully invoked
     void PlayFabApiTest::CloudScriptLambda(TestContext& testContext)
     {
         ExecuteCloudScriptRequest hwRequest;
@@ -537,8 +534,8 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    // CLIENT API
-    // Test that CloudScript errors can be deciphered
+    /// CLIENT API
+    /// Test that CloudScript errors can be deciphered
     void PlayFabApiTest::CloudScriptError(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -557,7 +554,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnCloudScriptError(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         bool success = true;
         success &= result.FunctionResult.isNull();
         success &= result.Error.notNull();
@@ -572,8 +569,8 @@ namespace PlayFabUnit
         }
     }
 
-    // CLIENT API
-    // Test that the client can publish custom PlayStream events
+    /// CLIENT API
+    /// Test that the client can publish custom PlayStream events
     void PlayFabApiTest::WriteEvent(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -595,12 +592,12 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnWritePlayerEvent(const WriteEventResponse&, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    // ENTITY API
-    // Verify that a client login can be converted into an entity token
+    /// ENTITY API
+    /// Verify that a client login can be converted into an entity token
     void PlayFabApiTest::GetEntityToken(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -617,7 +614,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetEntityToken(const GetEntityTokenResponse& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
 
         entityId = result.Entity->Id;
         entityType = result.Entity->Type;
@@ -636,10 +633,10 @@ namespace PlayFabUnit
         }
     }
 
-    // ENTITY API
-    // Test a sequence of calls that modifies entity objects,
-    //   and verifies that the next sequential API call contains updated information.
-    // Verify that the object is correctly modified on the next call.
+    /// ENTITY API
+    /// Test a sequence of calls that modifies entity objects,
+    ///   and verifies that the next sequential API call contains updated information.
+    /// Verify that the object is correctly modified on the next call.
     void PlayFabApiTest::ObjectApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -696,7 +693,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetObjects2(const GetObjectsResponse& result, void* customData)
     {
-        TestContext* testContext = static_cast<TestContext*>(customData);
+        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
 
         int actualDataValue = -1000;
         auto found = result.Objects.find(TEST_DATA_KEY);
@@ -719,11 +716,12 @@ namespace PlayFabUnit
         }
     }
 
-    //
-    //
-    // Add test calls to this method, after implementation
-    //
-    //
+    ///
+    ///
+    /// Add test calls to this method, after implementation
+    ///
+    ///
+
     void PlayFabApiTest::AddTests()
     {
         AddTest("InvalidSettings", &PlayFabApiTest::InvalidSettings);
@@ -734,7 +732,6 @@ namespace PlayFabUnit
         AddTest("LoginWithAdvertisingId", &PlayFabApiTest::LoginWithAdvertisingId);
         AddTest("UserDataApi", &PlayFabApiTest::UserDataApi);
         AddTest("PlayerStatisticsApi", &PlayFabApiTest::PlayerStatisticsApi);
-        AddTest("GetServerTime", &PlayFabApiTest::GetServerTime);
         AddTest("UserCharacter", &PlayFabApiTest::UserCharacter);
         AddTest("LeaderBoard", &PlayFabApiTest::LeaderBoard);
         AddTest("AccountInfo", &PlayFabApiTest::AccountInfo);
@@ -755,7 +752,7 @@ namespace PlayFabUnit
         entityId = "";
         entityType = "";
         testMessageInt = 0;
-        testMessageTime = PlayFab::GetPlayFabTimePointNow();
+        testMessageTime = 0;
     }
 
     void PlayFabApiTest::SetUp(TestContext& testContext)

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -1,18 +1,23 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include "TestAppPch.h"
-#include <string>
-#include <playfab/PlayFabClientApi.h>
+
+#ifndef DISABLE_PLAYFABCLIENT_API
+
+#include <chrono>
+
+#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabSettings.h>
-#include <playfab/PlayFabAuthenticationDataModels.h>
+
 #include <playfab/PlayFabAuthenticationApi.h>
+#include <playfab/PlayFabAuthenticationDataModels.h>
+#include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabClientDataModels.h>
-#include <playfab/PlayFabDataDataModels.h>
 #include <playfab/PlayFabDataApi.h>
-#include <playfab/PlayFabPlatformMacros.h>
+#include <playfab/PlayFabDataDataModels.h>
+
 #include "PlayFabApiTest.h"
 #include "TestContext.h"
-
 
 using namespace PlayFab;
 using namespace ClientModels;
@@ -35,12 +40,12 @@ namespace PlayFabUnit
 
     void PlayFabApiTest::OnErrorSharedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Unexpected error: " + error.ErrorMessage);
     }
 
-    /// CLIENT API
-    /// Try to deliberately cause a client-side validation error
+    // CLIENT API
+    // Try to deliberately cause a client-side validation error
     void PlayFabApiTest::InvalidSettings(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -57,13 +62,13 @@ namespace PlayFabUnit
             [&validTitleId](const LoginResult&, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            TestContext* testContext = static_cast<TestContext*>(customData);
             testContext->Fail("Expected API call to fail on the client side");
         },
             [&validTitleId](const PlayFabError& error, void* customData)
         {
             PlayFabSettings::staticSettings->titleId = validTitleId;
-            TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+            TestContext* testContext = static_cast<TestContext*>(customData);
             if (error.HttpCode == 0
                 && error.HttpStatus == "Client-side validation failure"
                 && error.ErrorCode == PlayFabErrorCode::PlayFabErrorInvalidParams
@@ -75,9 +80,9 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    /// CLIENT API
-    /// Try to deliberately log in with an inappropriate password,
-    ///   and verify that the error displays as expected.
+    // CLIENT API
+    // Try to deliberately log in with an inappropriate password,
+    //   and verify that the error displays as expected.
     void PlayFabApiTest::InvalidLogin(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -91,31 +96,28 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::LoginCallback(const LoginResult&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Expected login to fail");
     }
     void PlayFabApiTest::LoginFailedCallback(const PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (error.RequestId.empty())
         {
             testContext->Fail("The requestId should be set on a failure.");
         }
+        else if (error.ErrorMessage.find("password") != -1)
+        {
+            testContext->Pass(error.RequestId);
+        }
         else
-#endif // defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-            if (error.ErrorMessage.find("password") != -1)
-            {
-                testContext->Pass(error.RequestId);
-            }
-            else
-            {
-                testContext->Fail("Password error message not found: " + error.ErrorMessage);
-            }
+        {
+            testContext->Fail("Password error message not found: " + error.ErrorMessage);
+        }
     }
 
-    /// CLIENT API
-    /// Test that a lambda error callback can be successfully invoked
+    // CLIENT API
+    // Test that a lambda error callback can be successfully invoked
     void PlayFabApiTest::InvalidLoginLambda(TestContext& testContext)
     {
         LoginWithEmailAddressRequest request;
@@ -124,13 +126,13 @@ namespace PlayFabUnit
 
         PlayFabClientAPI::LoginWithEmailAddress(request,
             nullptr,
-            [](const PlayFabError& error, void* customData) { TestContext* testContext = reinterpret_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
+            [](const PlayFabError& error, void* customData) { TestContext* testContext = static_cast<TestContext*>(customData); if (error.ErrorMessage.find("password") != -1) testContext->Pass(); },
             &testContext);
     }
 
-    /// CLIENT API
-    /// Try to deliberately register a user with an invalid email and password
-    ///   Verify that errorDetails are populated correctly.
+    // CLIENT API
+    // Try to deliberately register a user with an invalid email and password
+    //   Verify that errorDetails are populated correctly.
     void PlayFabApiTest::InvalidRegistration(TestContext& testContext)
     {
         RegisterPlayFabUserRequest request;
@@ -145,7 +147,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::InvalidRegistrationSuccess(const RegisterPlayFabUserResult&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail("Expected registration to fail");
     }
     void PlayFabApiTest::InvalidRegistrationFail(const PlayFabError& error, void* customData)
@@ -158,7 +160,7 @@ namespace PlayFabUnit
         foundEmailMsg = (errorReport.find(expectedEmailMsg) != -1);
         foundPasswordMsg = (errorReport.find(expectedPasswordMsg) != -1);
 
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (foundEmailMsg && foundPasswordMsg)
         {
             testContext->Pass();
@@ -169,8 +171,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Attempt a successful login
+    // CLIENT API
+    // Attempt a successful login
     void PlayFabApiTest::LoginOrRegister(TestContext& testContext)
     {
         LoginWithCustomIDRequest request;
@@ -185,12 +187,12 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginOrRegister(const LoginResult& result, void* customData)
     {
         playFabId = result.PlayFabId;
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test that the login call sequence sends the AdvertisingId when set
+    // CLIENT API
+    // Test that the login call sequence sends the AdvertisingId when set
     void PlayFabApiTest::LoginWithAdvertisingId(TestContext& testContext)
     {
         PlayFabSettings::staticPlayer->advertisingIdType = PlayFabSettings::AD_TYPE_ANDROID_ID;
@@ -209,15 +211,15 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnLoginWithAdvertisingId(const LoginResult&, void* customData)
     {
         // TODO: Need to wait for the NEXT api call to complete, and then test PlayFabSettings::staticPlayer->advertisingIdType
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test a sequence of calls that modifies saved data,
-    ///   and verifies that the next sequential API call contains updated data.
-    /// Verify that the data is correctly modified on the next call.
-    /// Parameter types tested: string, Dictionary<string, string>, DateTime
+    // CLIENT API
+    // Test a sequence of calls that modifies saved data,
+    //   and verifies that the next sequential API call contains updated data.
+    // Verify that the data is correctly modified on the next call.
+    // Parameter types tested: string, Dictionary<string, string>
     void PlayFabApiTest::UserDataApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -241,15 +243,8 @@ namespace PlayFabUnit
         testMessageInt = (testMessageInt + 1) % 100;
         UpdateUserDataRequest updateRequest;
 
-        // itoa is not avaialable in android
-        char buffer[16];
         std::string temp;
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
-        sprintf(buffer, "%d", testMessageInt);
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
-        sprintf_s(buffer, "%d", testMessageInt);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_SWITCH || PLAYFAB_PLATFORM_SWITCH
-        temp.append(buffer);
+        AppendIntToString(testMessageInt, temp);
 
         updateRequest.Data[TEST_DATA_KEY] = temp;
         PlayFabClientAPI::UpdateUserData(updateRequest,
@@ -269,23 +264,8 @@ namespace PlayFabUnit
     {
         auto it = result.Data.find(TEST_DATA_KEY);
         int actualDataValue = (it == result.Data.end()) ? -1 : atoi(it->second.Value.c_str());
-        testMessageTime = (it == result.Data.end()) ? 0 : it->second.LastUpdated;
 
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        time_t now = time(nullptr);
-        struct tm timeinfo;
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        timeinfo = *gmtime(&now);
-        now = timegm(&timeinfo);
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
-        gmtime_s(&timeinfo, &now);
-        now = _mkgmtime(&timeinfo);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX
-        time_t minTime = now - (60 * 5);
-        time_t maxTime = now + (60 * 5);
-#endif // PLAYFAB_PLATFORM_PLAYSTATION
-
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (it == result.Data.end())
         {
             testContext->Fail("Expected user data not found.");
@@ -294,23 +274,49 @@ namespace PlayFabUnit
         {
             testContext->Fail("User data not updated as expected.");
         }
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION) // Issue 32699
-        else if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
-        {
-            testContext->Fail("DateTime not parsed correctly..");
-        }
-#endif // PLAYFAB_PLATFORM_PLAYSTATION
         else
         {
             testContext->Pass();
         }
     }
 
-    /// CLIENT API
-    /// Test a sequence of calls that modifies saved data,
-    ///   and verifies that the next sequential API call contains updated data.
-    /// Verify that the data is saved correctly, and that specific types are tested
-    /// Parameter types tested: Dictionary<string, int>
+    // CLIENT API
+    // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
+    // Parameter types tested: DateTime
+    void PlayFabApiTest::GetServerTime(TestContext& testContext)
+    {
+        if (!PlayFabClientAPI::IsClientLoggedIn())
+        {
+            testContext.Skip("Earlier tests failed to log in");
+            return;
+        }
+
+        GetTimeRequest request;
+        PlayFabClientAPI::GetTime(request,
+            Callback(&PlayFabApiTest::OnGetServerTime),
+            Callback(&PlayFabApiTest::OnErrorSharedCallback),
+            &testContext);
+    }
+    void PlayFabApiTest::OnGetServerTime(const GetTimeResult& result, void* customData)
+    {
+        testMessageTime = std::chrono::system_clock::from_time_t(result.Time);
+
+        TimePoint now = GetPlayFabTimePointNow();
+        TimePoint minTime = now - std::chrono::minutes(5);
+        TimePoint maxTime = now + std::chrono::minutes(5);
+
+        TestContext* testContext = static_cast<TestContext*>(customData);
+        if (!(minTime <= testMessageTime && testMessageTime <= maxTime))
+            testContext->Fail("DateTime not parsed correctly.");
+        else
+            testContext->Pass();
+    }
+
+    // CLIENT API
+    // Test a sequence of calls that modifies saved data,
+    //   and verifies that the next sequential API call contains updated data.
+    // Verify that the data is saved correctly, and that specific types are tested
+    // Parameter types tested: Dictionary<string, int>
     void PlayFabApiTest::PlayerStatisticsApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -371,7 +377,7 @@ namespace PlayFabUnit
             }
         }
 
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (actualStatValue == -1000)
         {
             testContext->Fail("Expected user statistic not found.");
@@ -386,9 +392,9 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Get or create the given test character for the given user
-    /// Parameter types tested: Contained-Classes, string
+    // CLIENT API
+    // Get or create the given test character for the given user
+    // Parameter types tested: Contained-Classes, string
     void PlayFabApiTest::UserCharacter(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -406,13 +412,13 @@ namespace PlayFabUnit
     void PlayFabApiTest::OnUserCharacter(const ListUsersCharactersResult&, void* customData)
     {
         // We aren't adding a character to this account, so there's nothing really to test here
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// CLIENT API
-    /// Test that leaderboard results can be requested
-    /// Parameter types tested: List of contained-classes
+    // CLIENT API
+    // Test that leaderboard results can be requested
+    // Parameter types tested: List of contained-classes
     void PlayFabApiTest::LeaderBoard(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -433,7 +439,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnClientLeaderBoard(const GetLeaderboardResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         if (result.Leaderboard.size() > 0) // We added too many users and stats to test for a specific user, so we just have to test for "any number of results" now
         {
             testContext->Pass();
@@ -444,9 +450,9 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that AccountInfo can be requested
-    /// Parameter types tested: List of enum-as-strings converted to list of enums
+    // CLIENT API
+    // Test that AccountInfo can be requested
+    // Parameter types tested: List of enum-as-strings converted to list of enums
     void PlayFabApiTest::AccountInfo(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -463,7 +469,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnAccountInfo(const GetAccountInfoResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         // Enums-by-name can't really be tested in C++, the way they can in other languages
         if (result.AccountInfo.isNull() || result.AccountInfo->TitleInfo.isNull() || result.AccountInfo->TitleInfo->Origination.isNull())
         {
@@ -475,8 +481,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that CloudScript can be properly set up and invoked
+    // CLIENT API
+    // Test that CloudScript can be properly set up and invoked
     void PlayFabApiTest::CloudScript(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -495,7 +501,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnHelloWorldCloudScript(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         std::string cloudScriptLogReport = "";
         if (result.Error.notNull())
         {
@@ -518,8 +524,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that a lambda success callback can be successfully invoked
+    // CLIENT API
+    // Test that a lambda success callback can be successfully invoked
     void PlayFabApiTest::CloudScriptLambda(TestContext& testContext)
     {
         ExecuteCloudScriptRequest hwRequest;
@@ -531,8 +537,8 @@ namespace PlayFabUnit
             &testContext);
     }
 
-    /// CLIENT API
-    /// Test that CloudScript errors can be deciphered
+    // CLIENT API
+    // Test that CloudScript errors can be deciphered
     void PlayFabApiTest::CloudScriptError(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -551,7 +557,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnCloudScriptError(const ExecuteCloudScriptResult& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         bool success = true;
         success &= result.FunctionResult.isNull();
         success &= result.Error.notNull();
@@ -566,8 +572,8 @@ namespace PlayFabUnit
         }
     }
 
-    /// CLIENT API
-    /// Test that the client can publish custom PlayStream events
+    // CLIENT API
+    // Test that the client can publish custom PlayStream events
     void PlayFabApiTest::WriteEvent(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -589,12 +595,12 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnWritePlayerEvent(const WriteEventResponse&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
-    /// ENTITY API
-    /// Verify that a client login can be converted into an entity token
+    // ENTITY API
+    // Verify that a client login can be converted into an entity token
     void PlayFabApiTest::GetEntityToken(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -611,7 +617,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetEntityToken(const GetEntityTokenResponse& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
 
         entityId = result.Entity->Id;
         entityType = result.Entity->Type;
@@ -630,10 +636,10 @@ namespace PlayFabUnit
         }
     }
 
-    /// ENTITY API
-    /// Test a sequence of calls that modifies entity objects,
-    ///   and verifies that the next sequential API call contains updated information.
-    /// Verify that the object is correctly modified on the next call.
+    // ENTITY API
+    // Test a sequence of calls that modifies entity objects,
+    //   and verifies that the next sequential API call contains updated information.
+    // Verify that the object is correctly modified on the next call.
     void PlayFabApiTest::ObjectApi(TestContext& testContext)
     {
         if (!PlayFabClientAPI::IsClientLoggedIn())
@@ -690,7 +696,7 @@ namespace PlayFabUnit
     }
     void PlayFabApiTest::OnGetObjects2(const GetObjectsResponse& result, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
 
         int actualDataValue = -1000;
         auto found = result.Objects.find(TEST_DATA_KEY);
@@ -713,12 +719,11 @@ namespace PlayFabUnit
         }
     }
 
-    ///
-    ///
-    /// Add test calls to this method, after implementation
-    ///
-    ///
-
+    //
+    //
+    // Add test calls to this method, after implementation
+    //
+    //
     void PlayFabApiTest::AddTests()
     {
         AddTest("InvalidSettings", &PlayFabApiTest::InvalidSettings);
@@ -729,6 +734,7 @@ namespace PlayFabUnit
         AddTest("LoginWithAdvertisingId", &PlayFabApiTest::LoginWithAdvertisingId);
         AddTest("UserDataApi", &PlayFabApiTest::UserDataApi);
         AddTest("PlayerStatisticsApi", &PlayFabApiTest::PlayerStatisticsApi);
+        AddTest("GetServerTime", &PlayFabApiTest::GetServerTime);
         AddTest("UserCharacter", &PlayFabApiTest::UserCharacter);
         AddTest("LeaderBoard", &PlayFabApiTest::LeaderBoard);
         AddTest("AccountInfo", &PlayFabApiTest::AccountInfo);
@@ -749,7 +755,7 @@ namespace PlayFabUnit
         entityId = "";
         entityType = "";
         testMessageInt = 0;
-        testMessageTime = 0;
+        testMessageTime = PlayFab::GetPlayFabTimePointNow();
     }
 
     void PlayFabApiTest::SetUp(TestContext& testContext)
@@ -771,3 +777,5 @@ namespace PlayFabUnit
         PlayFabSettings::ForgetAllCredentials();
     }
 }
+
+#endif

--- a/source/test/TestApp/PlayFabApiTest.h
+++ b/source/test/TestApp/PlayFabApiTest.h
@@ -4,8 +4,8 @@
 
 #ifndef DISABLE_PLAYFABCLIENT_API
 
-#include <playfab/PlayFabPlatformUtils.h>
-
+#include <functional>
+#include <string>
 #include "TestCase.h"
 
 namespace PlayFab
@@ -56,114 +56,108 @@ namespace PlayFabUnit
         std::string entityId;
         std::string entityType;
         int testMessageInt;
-        PlayFab::TimePoint testMessageTime;
+        time_t testMessageTime;
 
         void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-        // CLIENT API
-        // Try to deliberately cause a client-side validation error
+        /// CLIENT API
+        /// Try to deliberately cause a client-side validation error
         void InvalidSettings(TestContext& testContext);
 
-        // CLIENT API
-        // Try to deliberately log in with an inappropriate password,
-        //   and verify that the error displays as expected.
+        /// CLIENT API
+        /// Try to deliberately log in with an inappropriate password,
+        ///   and verify that the error displays as expected.
         void InvalidLogin(TestContext& testContext);
         void LoginCallback(const PlayFab::ClientModels::LoginResult&, void* customData);
         void LoginFailedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-        // CLIENT API
-        // Test that a lambda error callback can be successfully invoked
+        /// CLIENT API
+        /// Test that a lambda error callback can be successfully invoked
         void InvalidLoginLambda(TestContext& testContext);
 
-        // CLIENT API
-        // Try to deliberately register a user with an invalid email and password
-        //   Verify that errorDetails are populated correctly.
+        /// CLIENT API
+        /// Try to deliberately register a user with an invalid email and password
+        ///   Verify that errorDetails are populated correctly.
         void InvalidRegistration(TestContext& testContext);
         void InvalidRegistrationSuccess(const PlayFab::ClientModels::RegisterPlayFabUserResult&, void* customData);
         void InvalidRegistrationFail(const PlayFab::PlayFabError& error, void* customData);
 
-        // CLIENT API
-        // Attempt a successful login
+        /// CLIENT API
+        /// Attempt a successful login
         void LoginOrRegister(TestContext& testContext);
         void OnLoginOrRegister(const PlayFab::ClientModels::LoginResult& result, void* customData);
 
-        // CLIENT API
-        // Test that the login call sequence sends the AdvertisingId when set
+        /// CLIENT API
+        /// Test that the login call sequence sends the AdvertisingId when set
         void LoginWithAdvertisingId(TestContext& testContext);
         void OnLoginWithAdvertisingId(const PlayFab::ClientModels::LoginResult&, void* customData);
 
-        // CLIENT API
-        // Test a sequence of calls that modifies saved data,
-        //   and verifies that the next sequential API call contains updated data.
-        // Verify that the data is correctly modified on the next call.
-        // Parameter types tested: string, Dictionary<string, string>, DateTime
+        /// CLIENT API
+        /// Test a sequence of calls that modifies saved data,
+        ///   and verifies that the next sequential API call contains updated data.
+        /// Verify that the data is correctly modified on the next call.
+        /// Parameter types tested: string, Dictionary<string, string>, DateTime
         void UserDataApi(TestContext& testContext);
         void OnUserDataApiGet1(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
         void OnUserDataApiUpdate(const PlayFab::ClientModels::UpdateUserDataResult&, void* customData);
         void OnUserDataApiGet2(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
 
-        // CLIENT API
-        // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
-        // Parameter types tested: DateTime
-        void GetServerTime(TestContext& testContext);
-        void OnGetServerTime(const PlayFab::ClientModels::GetTimeResult& result, void* customData);
-
-        // CLIENT API
-        // Test a sequence of calls that modifies saved data,
-        //   and verifies that the next sequential API call contains updated data.
-        // Verify that the data is saved correctly, and that specific types are tested
-        // Parameter types tested: Dictionary<string, int>
+        /// CLIENT API
+        /// Test a sequence of calls that modifies saved data,
+        ///   and verifies that the next sequential API call contains updated data.
+        /// Verify that the data is saved correctly, and that specific types are tested
+        /// Parameter types tested: Dictionary<string, int>
         void PlayerStatisticsApi(TestContext& testContext);
         void OnPlayerStatisticsApiGet1(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
         void OnPlayerStatisticsApiUpdate(const PlayFab::ClientModels::UpdatePlayerStatisticsResult&, void* customData);
         void OnPlayerStatisticsApiGet2(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
 
-        // CLIENT API
-        // Get or create the given test character for the given user
-        // Parameter types tested: Contained-Classes, string
+        /// CLIENT API
+        /// Get or create the given test character for the given user
+        /// Parameter types tested: Contained-Classes, string
         void UserCharacter(TestContext& testContext);
         void OnUserCharacter(const PlayFab::ClientModels::ListUsersCharactersResult&, void* customData);
 
-        // CLIENT API
-        // Test that leaderboard results can be requested
-        // Parameter types tested: List of contained-classes
+        /// CLIENT API
+        /// Test that leaderboard results can be requested
+        /// Parameter types tested: List of contained-classes
         void LeaderBoard(TestContext& testContext);
         void OnClientLeaderBoard(const PlayFab::ClientModels::GetLeaderboardResult& result, void* customData);
 
-        // CLIENT API
-        // Test that AccountInfo can be requested
-        // Parameter types tested: List of enum-as-strings converted to list of enums
+        /// CLIENT API
+        /// Test that AccountInfo can be requested
+        /// Parameter types tested: List of enum-as-strings converted to list of enums
         void AccountInfo(TestContext& testContext);
         void OnAccountInfo(const PlayFab::ClientModels::GetAccountInfoResult& result, void* customData);
 
-        // CLIENT API
-        // Test that CloudScript can be properly set up and invoked
+        /// CLIENT API
+        /// Test that CloudScript can be properly set up and invoked
         void CloudScript(TestContext& testContext);
         void OnHelloWorldCloudScript(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-        // CLIENT API
-        // Test that a lambda success callback can be successfully invoked
+        /// CLIENT API
+        /// Test that a lambda success callback can be successfully invoked
         void CloudScriptLambda(TestContext& testContext);
 
-        // CLIENT API
-        // Test that CloudScript errors can be deciphered
+        /// CLIENT API
+        /// Test that CloudScript errors can be deciphered
         void CloudScriptError(TestContext& testContext);
         void OnCloudScriptError(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-        // CLIENT API
-        // Test that the client can publish custom PlayStream events
+        /// CLIENT API
+        /// Test that the client can publish custom PlayStream events
         void WriteEvent(TestContext& testContext);
         void OnWritePlayerEvent(const PlayFab::ClientModels::WriteEventResponse&, void* customData);
 
-        // ENTITY API
-        // Verify that a client login can be converted into an entity token
+        /// ENTITY API
+        /// Verify that a client login can be converted into an entity token
         void GetEntityToken(TestContext& testContext);
         void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void* customData);
 
-        // ENTITY API
-        // Test a sequence of calls that modifies entity objects,
-        //   and verifies that the next sequential API call contains updated information.
-        // Verify that the object is correctly modified on the next call.
+        /// ENTITY API
+        /// Test a sequence of calls that modifies entity objects,
+        ///   and verifies that the next sequential API call contains updated information.
+        /// Verify that the object is correctly modified on the next call.
         void ObjectApi(TestContext& testContext);
         void OnGetObjects1(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
         void OnSetObjects(const PlayFab::DataModels::SetObjectsResponse&, void* customData);

--- a/source/test/TestApp/PlayFabApiTest.h
+++ b/source/test/TestApp/PlayFabApiTest.h
@@ -2,8 +2,10 @@
 
 #pragma once
 
-#include <functional>
-#include <string>
+#ifndef DISABLE_PLAYFABCLIENT_API
+
+#include <playfab/PlayFabPlatformUtils.h>
+
 #include "TestCase.h"
 
 namespace PlayFab
@@ -42,140 +44,148 @@ namespace PlayFabUnit
 
     class PlayFabApiTest : public TestCase
     {
-        private:
-            // Fixed values provided from testInputs
-            bool TITLE_INFO_SET;
-            std::string USER_EMAIL;
+    private:
+        // Fixed values provided from testInputs
+        bool TITLE_INFO_SET;
+        std::string USER_EMAIL;
 
-            // Information fetched by appropriate API calls
-            const static std::string TEST_DATA_KEY;
-            const static std::string TEST_STAT_NAME;
-            std::string playFabId;
-            std::string entityId;
-            std::string entityType;
-            int testMessageInt;
-            time_t testMessageTime;
+        // Information fetched by appropriate API calls
+        const static std::string TEST_DATA_KEY;
+        const static std::string TEST_STAT_NAME;
+        std::string playFabId;
+        std::string entityId;
+        std::string entityType;
+        int testMessageInt;
+        PlayFab::TimePoint testMessageTime;
 
-            void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
+        void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Try to deliberately cause a client-side validation error
-            void InvalidSettings(TestContext& testContext);
+        // CLIENT API
+        // Try to deliberately cause a client-side validation error
+        void InvalidSettings(TestContext& testContext);
 
-            /// CLIENT API
-            /// Try to deliberately log in with an inappropriate password,
-            ///   and verify that the error displays as expected.
-            void InvalidLogin(TestContext& testContext);
-            void LoginCallback(const PlayFab::ClientModels::LoginResult&, void* customData);
-            void LoginFailedCallback(const PlayFab::PlayFabError& error, void* customData);
+        // CLIENT API
+        // Try to deliberately log in with an inappropriate password,
+        //   and verify that the error displays as expected.
+        void InvalidLogin(TestContext& testContext);
+        void LoginCallback(const PlayFab::ClientModels::LoginResult&, void* customData);
+        void LoginFailedCallback(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Test that a lambda error callback can be successfully invoked
-            void InvalidLoginLambda(TestContext& testContext);
+        // CLIENT API
+        // Test that a lambda error callback can be successfully invoked
+        void InvalidLoginLambda(TestContext& testContext);
 
-            /// CLIENT API
-            /// Try to deliberately register a user with an invalid email and password
-            ///   Verify that errorDetails are populated correctly.
-            void InvalidRegistration(TestContext& testContext);
-            void InvalidRegistrationSuccess(const PlayFab::ClientModels::RegisterPlayFabUserResult&, void* customData);
-            void InvalidRegistrationFail(const PlayFab::PlayFabError& error, void* customData);
+        // CLIENT API
+        // Try to deliberately register a user with an invalid email and password
+        //   Verify that errorDetails are populated correctly.
+        void InvalidRegistration(TestContext& testContext);
+        void InvalidRegistrationSuccess(const PlayFab::ClientModels::RegisterPlayFabUserResult&, void* customData);
+        void InvalidRegistrationFail(const PlayFab::PlayFabError& error, void* customData);
 
-            /// CLIENT API
-            /// Attempt a successful login
-            void LoginOrRegister(TestContext& testContext);
-            void OnLoginOrRegister(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        // CLIENT API
+        // Attempt a successful login
+        void LoginOrRegister(TestContext& testContext);
+        void OnLoginOrRegister(const PlayFab::ClientModels::LoginResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that the login call sequence sends the AdvertisingId when set
-            void LoginWithAdvertisingId(TestContext& testContext);
-            void OnLoginWithAdvertisingId(const PlayFab::ClientModels::LoginResult&, void* customData);
+        // CLIENT API
+        // Test that the login call sequence sends the AdvertisingId when set
+        void LoginWithAdvertisingId(TestContext& testContext);
+        void OnLoginWithAdvertisingId(const PlayFab::ClientModels::LoginResult&, void* customData);
 
-            /// CLIENT API
-            /// Test a sequence of calls that modifies saved data,
-            ///   and verifies that the next sequential API call contains updated data.
-            /// Verify that the data is correctly modified on the next call.
-            /// Parameter types tested: string, Dictionary<string, string>, DateTime
-            void UserDataApi(TestContext& testContext);
-            void OnUserDataApiGet1(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
-            void OnUserDataApiUpdate(const PlayFab::ClientModels::UpdateUserDataResult&, void* customData);
-            void OnUserDataApiGet2(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
+        // CLIENT API
+        // Test a sequence of calls that modifies saved data,
+        //   and verifies that the next sequential API call contains updated data.
+        // Verify that the data is correctly modified on the next call.
+        // Parameter types tested: string, Dictionary<string, string>, DateTime
+        void UserDataApi(TestContext& testContext);
+        void OnUserDataApiGet1(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
+        void OnUserDataApiUpdate(const PlayFab::ClientModels::UpdateUserDataResult&, void* customData);
+        void OnUserDataApiGet2(const PlayFab::ClientModels::GetUserDataResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test a sequence of calls that modifies saved data,
-            ///   and verifies that the next sequential API call contains updated data.
-            /// Verify that the data is saved correctly, and that specific types are tested
-            /// Parameter types tested: Dictionary<string, int>
-            void PlayerStatisticsApi(TestContext& testContext);
-            void OnPlayerStatisticsApiGet1(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
-            void OnPlayerStatisticsApiUpdate(const PlayFab::ClientModels::UpdatePlayerStatisticsResult&, void* customData);
-            void OnPlayerStatisticsApiGet2(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
+        // CLIENT API
+        // Verify that the timestamp returned is within 5 minutes of the time according to the local timezone for the current machine.
+        // Parameter types tested: DateTime
+        void GetServerTime(TestContext& testContext);
+        void OnGetServerTime(const PlayFab::ClientModels::GetTimeResult& result, void* customData);
 
-            /// CLIENT API
-            /// Get or create the given test character for the given user
-            /// Parameter types tested: Contained-Classes, string
-            void UserCharacter(TestContext& testContext);
-            void OnUserCharacter(const PlayFab::ClientModels::ListUsersCharactersResult&, void* customData);
+        // CLIENT API
+        // Test a sequence of calls that modifies saved data,
+        //   and verifies that the next sequential API call contains updated data.
+        // Verify that the data is saved correctly, and that specific types are tested
+        // Parameter types tested: Dictionary<string, int>
+        void PlayerStatisticsApi(TestContext& testContext);
+        void OnPlayerStatisticsApiGet1(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
+        void OnPlayerStatisticsApiUpdate(const PlayFab::ClientModels::UpdatePlayerStatisticsResult&, void* customData);
+        void OnPlayerStatisticsApiGet2(const PlayFab::ClientModels::GetPlayerStatisticsResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that leaderboard results can be requested
-            /// Parameter types tested: List of contained-classes
-            void LeaderBoard(TestContext& testContext);
-            void OnClientLeaderBoard(const PlayFab::ClientModels::GetLeaderboardResult& result, void* customData);
+        // CLIENT API
+        // Get or create the given test character for the given user
+        // Parameter types tested: Contained-Classes, string
+        void UserCharacter(TestContext& testContext);
+        void OnUserCharacter(const PlayFab::ClientModels::ListUsersCharactersResult&, void* customData);
 
-            /// CLIENT API
-            /// Test that AccountInfo can be requested
-            /// Parameter types tested: List of enum-as-strings converted to list of enums
-            void AccountInfo(TestContext& testContext);
-            void OnAccountInfo(const PlayFab::ClientModels::GetAccountInfoResult& result, void* customData);
+        // CLIENT API
+        // Test that leaderboard results can be requested
+        // Parameter types tested: List of contained-classes
+        void LeaderBoard(TestContext& testContext);
+        void OnClientLeaderBoard(const PlayFab::ClientModels::GetLeaderboardResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that CloudScript can be properly set up and invoked
-            void CloudScript(TestContext& testContext);
-            void OnHelloWorldCloudScript(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
+        // CLIENT API
+        // Test that AccountInfo can be requested
+        // Parameter types tested: List of enum-as-strings converted to list of enums
+        void AccountInfo(TestContext& testContext);
+        void OnAccountInfo(const PlayFab::ClientModels::GetAccountInfoResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that a lambda success callback can be successfully invoked
-            void CloudScriptLambda(TestContext& testContext);
+        // CLIENT API
+        // Test that CloudScript can be properly set up and invoked
+        void CloudScript(TestContext& testContext);
+        void OnHelloWorldCloudScript(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-            /// CLIENT API
-            /// Test that CloudScript errors can be deciphered
-            void CloudScriptError(TestContext& testContext);
-            void OnCloudScriptError(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
+        // CLIENT API
+        // Test that a lambda success callback can be successfully invoked
+        void CloudScriptLambda(TestContext& testContext);
 
-            /// CLIENT API
-            /// Test that the client can publish custom PlayStream events
-            void WriteEvent(TestContext& testContext);
-            void OnWritePlayerEvent(const PlayFab::ClientModels::WriteEventResponse&, void* customData);
+        // CLIENT API
+        // Test that CloudScript errors can be deciphered
+        void CloudScriptError(TestContext& testContext);
+        void OnCloudScriptError(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* customData);
 
-            /// ENTITY API
-            /// Verify that a client login can be converted into an entity token
-            void GetEntityToken(TestContext& testContext);
-            void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void* customData);
+        // CLIENT API
+        // Test that the client can publish custom PlayStream events
+        void WriteEvent(TestContext& testContext);
+        void OnWritePlayerEvent(const PlayFab::ClientModels::WriteEventResponse&, void* customData);
 
-            /// ENTITY API
-            /// Test a sequence of calls that modifies entity objects,
-            ///   and verifies that the next sequential API call contains updated information.
-            /// Verify that the object is correctly modified on the next call.
-            void ObjectApi(TestContext& testContext);
-            void OnGetObjects1(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
-            void OnSetObjects(const PlayFab::DataModels::SetObjectsResponse&, void* customData);
-            void OnGetObjects2(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
+        // ENTITY API
+        // Verify that a client login can be converted into an entity token
+        void GetEntityToken(TestContext& testContext);
+        void OnGetEntityToken(const PlayFab::AuthenticationModels::GetEntityTokenResponse& result, void* customData);
 
-            // Utility
-            template<typename T> std::function<void(const T&, void*)> Callback(void(PlayFabApiTest::*func)(const T&, void*))
-            {
-                return std::bind(func, this, std::placeholders::_1, std::placeholders::_2);
-            }
+        // ENTITY API
+        // Test a sequence of calls that modifies entity objects,
+        //   and verifies that the next sequential API call contains updated information.
+        // Verify that the object is correctly modified on the next call.
+        void ObjectApi(TestContext& testContext);
+        void OnGetObjects1(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
+        void OnSetObjects(const PlayFab::DataModels::SetObjectsResponse&, void* customData);
+        void OnGetObjects2(const PlayFab::DataModels::GetObjectsResponse& result, void* customData);
 
-        protected:
-            void AddTests() override;
+        // Utility
+        template<typename T> std::function<void(const T&, void*)> Callback(void(PlayFabApiTest::* func)(const T&, void*))
+        {
+            return std::bind(func, this, std::placeholders::_1, std::placeholders::_2);
+        }
 
-        public:
-            void SetTitleInfo(TestTitleData& testInputs);
+    protected:
+        void AddTests() override;
 
-            void ClassSetUp() override;
-            void SetUp(TestContext& /*testContext*/) override;
-            void Tick(TestContext& testContext) override;
-            void ClassTearDown() override;
+    public:
+        void SetTitleInfo(TestTitleData& testInputs);
+
+        void ClassSetUp() override;
+        void SetUp(TestContext& /*testContext*/) override;
+        void Tick(TestContext& testContext) override;
+        void ClassTearDown() override;
     };
 }
+
+#endif

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -1,6 +1,9 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include "TestAppPch.h"
+
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include <thread>
 #include <chrono>
 #include <playfab/PlayFabClientApi.h>
@@ -259,7 +262,7 @@ namespace PlayFabUnit
         // Sleep while waiting for log in to complete.
         while (!loginComplete)
         {
-            std::this_thread::sleep_for(TimeValueMs(100));
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
     }
 
@@ -326,3 +329,5 @@ namespace PlayFabUnit
         return event;
     }
 }
+
+#endif

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include <functional>
 #include <string>
 #include <playfab/PlayFabEventApi.h>
@@ -81,3 +83,5 @@ namespace PlayFabUnit
             void ClassTearDown() override;
     };
 }
+
+#endif

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
@@ -2,6 +2,8 @@
 
 #include "TestAppPch.h"
 
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include <playfab/PlayFabClientInstanceApi.h>
 #include <playfab/PlayFabSettings.h>
 #include "TestContext.h"
@@ -151,3 +153,5 @@ namespace PlayFabUnit
         multiUser2ClientApi = nullptr;
     }
 }
+
+#endif

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.h
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include "TestCase.h"
 
 namespace PlayFab
@@ -51,3 +53,5 @@ namespace PlayFabUnit
         void ClassTearDown() override;
     };
 }
+
+#endif

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
@@ -1,6 +1,9 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
 
 #include "TestAppPch.h"
+
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include <playfab/PlayFabClientApi.h>
 #include <playfab/PlayFabSettings.h>
 #include "TestContext.h"
@@ -149,3 +152,5 @@ namespace PlayFabUnit
         multiUser2Context = nullptr;
     }
 }
+
+#endif

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.h
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#ifndef DISABLE_PLAYFABCLIENT_API
+
 #include "TestCase.h"
 
 namespace PlayFab
@@ -50,3 +52,5 @@ namespace PlayFabUnit
         void ClassTearDown() override;
     };
 }
+
+#endif

--- a/source/test/TestApp/TestApp.cpp
+++ b/source/test/TestApp/TestApp.cpp
@@ -21,6 +21,25 @@ using namespace ClientModels;
 
 namespace PlayFabUnit
 {
+    void TestApp::Log(const char* format, ...)
+    {
+        static char message[4096];
+
+        va_list args;
+        va_start(args, format);
+#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        vsnprintf_s(message, sizeof(message), format, args);
+#elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_SWITCH)
+        vsnprintf(message, sizeof(message), format, args);
+#else
+        _vsnprintf_s(message, sizeof(message), format, args);
+#endif
+        va_end(args);
+
+        // Output the message in a platform-dependent way.
+        LogPut(message);
+    }
+
     int TestApp::Main()
     {
         // Load the TestTitleData
@@ -41,6 +60,7 @@ namespace PlayFabUnit
         // Initialize the test runner/test data.
         TestRunner testRunner;
 
+#ifndef DISABLE_PLAYFABCLIENT_API
         // Add PlayFab API tests.
         PlayFabApiTest pfApiTest;
         pfApiTest.SetTitleInfo(testInputs);
@@ -54,10 +74,12 @@ namespace PlayFabUnit
 
         PlayFabTestMultiUserInstance pfMultiUserInstanceTest;
         testRunner.Add(pfMultiUserInstanceTest);
+#endif
 
         // Run the tests (blocks until all tests have finished).
         testRunner.Run();
 
+#ifndef DISABLE_PLAYFABCLIENT_API
         // Publish the test report via cloud script (and wait for it to finish).
         LoginWithCustomIDRequest request;
         request.CustomId = PlayFabSettings::buildIdentifier;
@@ -71,6 +93,7 @@ namespace PlayFabUnit
         {
             std::this_thread::sleep_for(TimeValueMs(100));
         }
+#endif
 
         // Publish the test summary (including cloud script response) to STDOUT.
         Log("%s\n%s\n", testRunner.suiteTestSummary.c_str(), cloudResponse.c_str());
@@ -108,25 +131,7 @@ namespace PlayFabUnit
         return parsedSuccessfully;
     }
 
-    void TestApp::Log(const char* format, ...)
-    {
-        static char message[4096];
-
-        va_list args;
-        va_start(args, format);
-#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        vsnprintf_s(message, sizeof(message), format, args);
-#elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_SWITCH)
-        vsnprintf(message, sizeof(message), format, args);
-#else
-        _vsnprintf_s(message, sizeof(message), format, args);
-#endif
-        va_end(args);
-
-        // Output the message in a platform-dependent way.
-        LogPut(message);
-    }
-
+#ifndef DISABLE_PLAYFABCLIENT_API
     void TestApp::OnPostReportLogin(const LoginResult& result, void* customData)
     {
         cloudPlayFabId = result.PlayFabId;
@@ -170,4 +175,5 @@ namespace PlayFabUnit
     {
         cloudResponse = "Failed to report results via cloud script: " + error.GenerateErrorReport();
     }
+#endif
 }

--- a/source/test/TestApp/TestApp.h
+++ b/source/test/TestApp/TestApp.h
@@ -21,25 +21,25 @@ namespace PlayFabUnit
 {
     class TestApp
     {
-        public:
-            int Main();
+    public:
+        int Main();
+        static void Log(const char* format, ...);
+        static void LogPut(const char* message);
 
-        private:
-            // Cloud Report
-            std::string cloudResponse = "";
-            std::string cloudPlayFabId = "";
-            void OnPostReportLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
-            void OnPostReportComplete(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* /*customData*/);
-            void OnPostReportError(const PlayFab::PlayFabError& error, void* /*customData*/);
+    private:
+        // Cloud Report
+        std::string cloudResponse = "";
+        std::string cloudPlayFabId = "";
+        void OnPostReportLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
+        void OnPostReportComplete(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* /*customData*/);
+        void OnPostReportError(const PlayFab::PlayFabError& error, void* /*customData*/);
 
-            // Utility
-            static bool LoadTitleData(TestTitleData& titleData);
-            static void Log(const char* format, ...);
+        // Utility
+        static bool LoadTitleData(TestTitleData& titleData);
 
-            // Partial class methods
-            // Each platform gets its own file and implementation of the following methods, since the logic
-            // is likely to be very different on all of them.
-            static bool LoadTitleDataJson(std::shared_ptr<char*>& testDataJsonPtr, size_t& testDataJsonLen);
-            static void LogPut(const char* message);
+        // Partial class methods
+        // Each platform gets its own file and implementation of the following methods, since the logic
+        // is likely to be very different on all of them.
+        static bool LoadTitleDataJson(std::shared_ptr<char*>& testDataJsonPtr, size_t& testDataJsonLen);
     };
 }


### PR DESCRIPTION
Resolves allocation/deallocation/segment-fault/out-of-bounds issues for XPlat, after the instance data isolation fixes
The fix itself, is to ensure that all fields always exist on these classes, regardless of defines, and only their access level changes when defines are changed.
Full design discussion and notes available in task 38104.

Other changes:
Separate the TestApp into TestClientApp and TestServerApp so that we can test both scenarios.
Add some allocations/deletes to the begining of the test-apps so they can verify these fixes work as expected.
Wrapping a lot of files in #ifndef DISABLE_PLAYFABCLIENT_API, since they were always client specific (but wasn't well tested before)
Making the logging funcs in TestApp public, so they can be called from the main funcs.