### PR TITLE
Update PlayFabEventTest.cpp

### DIFF
--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -224,7 +224,7 @@ namespace PlayFabUnit
 
     void PlayFabEventTest::GenericMultiThreadedTest(uint32_t pNumThreads, uint32_t pNumEventsPerThread)
     {
-        std::atomic<uint32_t> eventsRemaining = pNumThreads * pNumEventsPerThread;
+        std::atomic<uint32_t> eventsRemaining(pNumThreads * pNumEventsPerThread);
         for (uint32_t thread = 0; thread < pNumThreads; ++thread)
         {
             testThreadPool.emplace_back(

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -234,7 +234,7 @@ namespace PlayFabUnit
                     for (uint32_t i = 0; i < pNumEventsPerThread; ++i)
                     {
                         (*api)->EmitEvent(MakeEvent(0, PlayFabEventType::Default),
-                            [&eventsRemaining, pNumEventsPerThread]
+                            [&eventsRemaining]
                             (std::shared_ptr<const PlayFab::IPlayFabEvent>, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse>)
                             {
                                 if (--eventsRemaining == 0)


### PR DESCRIPTION
Android and iOS deleted the copy constructor for unsigned ints on std::atomic. We get around that now by not making a copy, but just calling the always valid constructor!