### PR TITLE
Toddbell/curl issue

### DIFF
--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -205,7 +205,7 @@ namespace PlayFab
         long curlHttpResponseCode = 0;
         curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, &curlHttpResponseCode);
 
-        reqContainer.errorWrapper.RequestId = requestContainer.GetRequestId();
+        reqContainer.errorWrapper.RequestId = reqContainer.GetRequestId();
 
         if (res != CURLE_OK)
         {


### PR DESCRIPTION
Fix for Curl where we were attempting to access a requestContainer that was a uniquePtr instead of a reqContainer that was the reference originally intended for use throughout the function.