### PR TITLE
Removing unneeded and unsafe functions

### DIFF
--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -19,18 +19,6 @@ namespace PlayFab
         return time(0);
     }
 
-    inline void AppendIntToString(int value, std::string& output)
-    {
-        // itoa is not available in android
-        char buffer[16];
-#if defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_PLAYSTATION) || defined(PLAYFAB_PLATFORM_SWITCH)
-        sprintf(buffer, "%d", value);
-#else // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_PLAYSTATION || PLAYFAB_PLATFORM_SWITCH
-        sprintf_s(buffer, "%d", value);
-#endif // PLAYFAB_PLATFORM_IOS || PLAYFAB_PLATFORM_ANDROID || PLAYFAB_PLATFORM_LINUX || PLAYFAB_PLATFORM_PLAYSTATION || PLAYFAB_PLATFORM_SWITCH
-        output.append(buffer);
-    }
-
     inline std::string LocalTimeTToUtcString(time_t now)
     {
         tm timeInfo;

--- a/source/test/TestApp/PlayFabApiTest.cpp
+++ b/source/test/TestApp/PlayFabApiTest.cpp
@@ -244,8 +244,7 @@ namespace PlayFabUnit
         testMessageInt = (testMessageInt + 1) % 100;
         UpdateUserDataRequest updateRequest;
 
-        std::string temp;
-        AppendIntToString(testMessageInt, temp);
+        std::string temp = std::to_string(testMessageInt);
 
         updateRequest.Data[TEST_DATA_KEY] = temp;
         PlayFabClientAPI::UpdateUserData(updateRequest,


### PR DESCRIPTION
We no longer need AppendIntToString since 
1.) its only used in tests 
2.) it uses special _s functions which have been problematic for console tests
3.) Since we use C++ 11 constructs, we can expect std::to_string to be present for our test use case