### PR TITLE
Update PlayFabPlatformUtils.h

### DIFF
--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -57,6 +57,7 @@ namespace PlayFab
 
         std::istringstream iss(utcString);
         iss >> std::get_time(&timeStruct, "%Y-%m-%dT%T");
+        timeStruct.tm_isdst = 0;  // 0 means "not in DST" PlayFab assumes UTC/Zulu always
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         output = mktime(&timeStruct);
 #elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)


### PR DESCRIPTION
we need to explicitly set this flag to either on or off to ensure all platoforms behave in the exact same manner. Right now that flag is left dangling and garbage is allowed to fill that space (so default case is undefined behavior from the C++ reference: http://www.cplusplus.com/reference/ctime/tm/)