### PR TITLE
Toddbell/gmtime fix

### DIFF
--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -49,7 +49,7 @@ namespace PlayFab
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         output = mktime(&timeStruct);
 #elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        output = gmtime_r(&timeStruct);
+        output = gmtime_r(&output, &timeStruct);
 #else
         output = _mkgmtime(&timeStruct);
 #endif

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -49,7 +49,7 @@ namespace PlayFab
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         output = mktime(&timeStruct);
 #elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        output = timegm(&timeStruct);
+        output = gmtime_r(&timeStruct);
 #else
         output = _mkgmtime(&timeStruct);
 #endif

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -49,7 +49,7 @@ namespace PlayFab
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         output = mktime(&timeStruct);
 #elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        output = gmtime_r(&output, &timeStruct);
+        gmtime_r(&output, &timeStruct);
 #else
         output = _mkgmtime(&timeStruct);
 #endif


### PR DESCRIPTION
This fixes a non-thread safe call for the linux platform (and iOS, android)