### PR TITLE
Remove many shared_ptr<Type*>

### DIFF
--- a/make.js
+++ b/make.js
@@ -239,7 +239,7 @@ function getPropertySafeName(property) {
 }
 
 function getRequestActions(tabbing, apiCall, isInstanceApi) {
-    //TODO Bug 6594: add to this titleId check. 
+    //TODO Bug 6594: add to this titleId check.
     // If this titleId does not exist we should be throwing an error informing the user MUST have a titleId.
     if (apiCall.result === "LoginResult" || apiCall.result === "RegisterPlayFabUserResult")
         return tabbing + "if (request.TitleId.empty())\n"

--- a/source/code/include/playfab/PlayFabEventApi.h
+++ b/source/code/include/playfab/PlayFabEventApi.h
@@ -23,7 +23,7 @@ namespace PlayFab
         /// - callback is a pointer to user's function to receive a notification about the outcome of the operation when the event is sent out or any error occurred.
         /// </summary>
         void EmitEvent(std::unique_ptr<const IPlayFabEvent> event, const PlayFabEmitEventCallback callback) const;
-        
+
         void EmitEvent(std::unique_ptr<const IPlayFabEvent> event, std::function<void(std::shared_ptr<const IPlayFabEvent>, std::shared_ptr<const IPlayFabEmitEventResponse>)> callback) const;
 
     private:

--- a/source/code/include/playfab/PlayFabEventBuffer.h
+++ b/source/code/include/playfab/PlayFabEventBuffer.h
@@ -7,8 +7,8 @@ namespace PlayFab
 {
 #pragma pack(push)
 #pragma pack(8) // conservative memory alignment control to provide maximum platform compatibility
-    /// <summary> 
-    /// A "packet" (wrapper) for an event request. The packets are internal custom allocations inside the buffer. 
+    /// <summary>
+    /// A "packet" (wrapper) for an event request. The packets are internal custom allocations inside the buffer.
     /// Their purpose is to reduce heap churn as additional data about event (e.g. some event metadata) needs to be stored
     /// so that a wrapper object is not created on the heap for each event.
     /// The implementation is based on the implementation of FullEvent struct in Microsoft Gaming Cloud CELL library.
@@ -85,7 +85,7 @@ namespace PlayFab
         const size_t buffMask; // A bit mask that is used for very fast buffer pointer arithmetics.
                                // The buffer's length is always a power of two and the buffer mask is (length - 1).
                                // For example if buffer length is 0x100 (256) then buffer mask is 0xFF (255)
-                               // (or 100000000 and 011111111 in binary form). Performing binary "&" operations 
+                               // (or 100000000 and 011111111 in binary form). Performing binary "&" operations
                                // with a mask like that allows for efficient pointer adjustments in a circular buffer.
 
         std::unique_ptr<uint8_t[]> bufferArray;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -72,13 +72,13 @@ namespace PlayFab
         virtual void SendBatch(size_t& batchCounter);
 
     private:
-        void WorkerThread();        
+        void WorkerThread();
         void WriteEventsApiCallback(const EventsModels::WriteEventsResponse& result, void* customData);
         void WriteEventsApiErrorCallback(const PlayFabError& error, void* customData);
         void CallbackRequest(std::shared_ptr<const IPlayFabEmitEventRequest> request, std::shared_ptr<const IPlayFabEmitEventResponse> response);
 
     protected:
-        // PlayFab's public Events API (e.g. WriteEvents method) allows to pass only a pointer to some custom object (void* customData) that will be relayed back to its callbacks. 
+        // PlayFab's public Events API (e.g. WriteEvents method) allows to pass only a pointer to some custom object (void* customData) that will be relayed back to its callbacks.
         // This is the only reliable way to relate a particular Events API call with its particular callbacks since it is an asynchronous operation.
         // We are using that feature (custom pointer relay) because we need to know which batch it was when we receive a callback from the Events API.
         // To keep track of all batches currently in flight (i.e. those for which we called Events API) we need to have a container with controllable size

--- a/source/code/include/playfab/PlayFabPluginManager.h
+++ b/source/code/include/playfab/PlayFabPluginManager.h
@@ -38,7 +38,7 @@ namespace PlayFab
 
         /// <summary>
         /// updates the process of making post requests.
-        /// This method can be used when plugin is not using a working thread and instead should execute 
+        /// This method can be used when plugin is not using a working thread and instead should execute
         /// its long-running operations via polling using this method.
         /// Returns number of currently pending post requests.
         /// </summary>

--- a/source/code/include/playfab/PlayFabSpinLock.h
+++ b/source/code/include/playfab/PlayFabSpinLock.h
@@ -3,7 +3,7 @@
 #include <atomic>
 #include <thread>
 
-namespace PlayFab 
+namespace PlayFab
 {
     /// <summary>
     /// The implementation of a lightweight atomic spin that allows to control access to critical sections of code

--- a/source/code/include/playfab/PlayFabTransportHeaders.h
+++ b/source/code/include/playfab/PlayFabTransportHeaders.h
@@ -1,5 +1,5 @@
 // Copyright (C) Microsoft Corporation. All rights reserved.
-// 
+//
 // This header file is used to include headers of transport plugins supported on each platform.
 
 #pragma once

--- a/source/code/source/playfab/PlayFabError.cpp
+++ b/source/code/source/playfab/PlayFabError.cpp
@@ -35,7 +35,7 @@ namespace PlayFab
         {
             ErrorMessage = ErrorMessage_member.asString();
         }
-        
+
         ErrorDetails = input["errorDetails"];
         Data = input["data"];
     }

--- a/source/code/source/playfab/PlayFabEventApi.cpp
+++ b/source/code/source/playfab/PlayFabEventApi.cpp
@@ -7,7 +7,7 @@
 namespace PlayFab
 {
     PlayFabEventAPI::PlayFabEventAPI() :
-        eventRouter(std::shared_ptr<PlayFabEventRouter>(new PlayFabEventRouter())) // default event router
+        eventRouter(std::make_shared<PlayFabEventRouter>()) // default event router
     {
     }
 

--- a/source/code/source/playfab/PlayFabEventBuffer.cpp
+++ b/source/code/source/playfab/PlayFabEventBuffer.cpp
@@ -21,7 +21,7 @@ namespace PlayFab
     }
 
     PlayFabEventBuffer::PlayFabEventBuffer(
-        const size_t bufferSize) 
+        const size_t bufferSize)
         :
         disabled(false),
         buffMask(AdjustBufferSize(bufferSize) - 1),
@@ -123,7 +123,7 @@ namespace PlayFab
 
         // event is available; return its values
         request = std::move(event->eventRequest);
-        
+
         // set new head (new last consumed event)
         head.store(event, std::memory_order_release);
 

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -155,7 +155,7 @@ namespace PlayFab
         using clock = std::chrono::steady_clock;
         using Result = PlayFabEventBuffer::EventConsumingResult;
         std::shared_ptr<const IPlayFabEmitEventRequest> request;
-        size_t batchCounter = 0; // used to track uniqueness of batches in the map
+        size_t batchCounter = 1; // used to track uniqueness of batches in the map
         std::chrono::steady_clock::time_point momentBatchStarted; // used to track when a currently assembled batch got its first event
 
         while (this->isWorkerThreadRunning)

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -37,7 +37,7 @@ namespace PlayFab
                 {
                     PlayFabSettings::globalErrorHandler(container.errorWrapper, container.GetCustomData());
                 }
-                
+
                 if (container.errorCallback != nullptr)
                 {
                     container.errorCallback(container.errorWrapper, container.GetCustomData());
@@ -137,7 +137,7 @@ namespace PlayFab
         {
             Json::Value value;
             value["ErrorCode"] = Json::Value(result.errorCode);
-            
+
             Json::Value each_regionCenterResult;
             for (int i = 0; i < result.regionResults.size(); ++i)
             {
@@ -185,7 +185,7 @@ namespace PlayFab
             ListQosServersRequest request;
             PlayFabMultiplayerAPI::ListQosServers(request, ListQosServersSuccessCallBack, ListQosServersFailureCallBack, reinterpret_cast<void*>(this));
         }
-        
+
         void PlayFabQoSApi::ListQosServersSuccessCallBack(const ListQosServersResponse& result, void* customData)
         {
             // Custom data received is a pointer to our api object
@@ -247,7 +247,7 @@ namespace PlayFab
             // Setup sockets based on the number of threads
             for (unsigned int i = 0; i < numThreads; ++i)
             {
-                shared_ptr<QoSSocket> socket = shared_ptr<QoSSocket>(new QoSSocket());
+                shared_ptr<QoSSocket> socket = make_shared<QoSSocket>();
 
                 int errorCode;
                 if ((errorCode = socket->ConfigureSocket(timeoutMs)) == 0)
@@ -334,7 +334,7 @@ namespace PlayFab
             // Accumulate final results
             for (size_t i = 0; i < numThreads; ++i)
             {
-                // If the result is valid and available 
+                // If the result is valid and available
                 if (asyncPingResults[i].valid())
                 {
                     std::chrono::milliseconds pingWaitTime = std::chrono::milliseconds(timeoutMs);

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -33,7 +33,7 @@ namespace PlayFab
 
         int XPlatSocket::InitializeSocket()
         {
-            // If the socket is already initialized, return 0, 
+            // If the socket is already initialized, return 0,
             // else initialize it
             if (initialized)
             {

--- a/source/test/TestApp/PlayFabTestAlloc.cpp
+++ b/source/test/TestApp/PlayFabTestAlloc.cpp
@@ -4,6 +4,7 @@
 
 #include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabAuthenticationContext.h>
+#include <playfab/PlayFabAuthenticationInstanceAPI.h>
 #include "TestContext.h"
 #include "PlayFabTestAlloc.h"
 
@@ -67,10 +68,28 @@ namespace PlayFabUnit
         testContext.Pass();
     }
 
+    void PlayFabTestAlloc::TestApiInstanceAlloc(TestContext& testContext)
+    {
+        // If anything fails here, it'll be a straight program crash
+
+        // Context
+        PlayFab::PlayFabAuthenticationInstanceAPI* testPtrApi = new PlayFab::PlayFabAuthenticationInstanceAPI();
+        delete testPtrApi;
+
+        std::shared_ptr<PlayFab::PlayFabAuthenticationInstanceAPI> testSpApi = std::make_shared<PlayFab::PlayFabAuthenticationInstanceAPI>();
+        testSpApi.reset();
+
+        std::shared_ptr<PlayFab::PlayFabAuthenticationInstanceAPI> testNSpApi = std::shared_ptr<PlayFab::PlayFabAuthenticationInstanceAPI>(new PlayFab::PlayFabAuthenticationInstanceAPI());
+        testNSpApi.reset();
+
+        testContext.Pass();
+    }
+
     void PlayFabTestAlloc::AddTests()
     {
         AddTest("TestApiSettingsAlloc", &PlayFabTestAlloc::TestApiSettingsAlloc);
         AddTest("TestAuthContextAlloc", &PlayFabTestAlloc::TestAuthContextAlloc);
+        AddTest("TestApiInstanceAlloc", &PlayFabTestAlloc::TestApiInstanceAlloc);
     }
 
     void PlayFabTestAlloc::Tick(TestContext& /*testContext*/)

--- a/source/test/TestApp/PlayFabTestAlloc.h
+++ b/source/test/TestApp/PlayFabTestAlloc.h
@@ -11,6 +11,7 @@ namespace PlayFabUnit
     private:
         void TestApiSettingsAlloc(TestContext& testContext);
         void TestAuthContextAlloc(TestContext& testContext);
+        void TestApiInstanceAlloc(TestContext& testContext);
 
     protected:
         void AddTests() override;

--- a/source/test/TestApp/TestCase.h
+++ b/source/test/TestApp/TestCase.h
@@ -11,90 +11,90 @@ namespace PlayFabUnit
 {
     struct TestContext;
 
-    typedef std::list<std::shared_ptr<TestContext*>> TestList;
+    typedef std::list<std::shared_ptr<TestContext>> TestList;
 
     class TestCase
     {
-        public:
-            TestCase()
+    public:
+        TestCase()
+        {
+            testList = std::make_shared<TestList>();
+        }
+
+        /// <summary>
+        /// Provide read-only access to the test list.
+        /// Will trigger building the test list, if it's not already populated.
+        /// <summary>
+        std::shared_ptr<TestList> GetTests()
+        {
+            if (testList->empty())
             {
-                testList = std::make_shared<TestList*>(new TestList());
+                AddTests();
             }
 
-            /// <summary>
-            /// Provide read-only access to the test list.
-            /// Will trigger building the test list, if it's not already populated.
-            /// <summary>
-            std::shared_ptr<TestList*> GetTests()
-            {
-                if ((*testList)->empty())
-                {
-                    AddTests();
-                }
+            return testList;
+        }
 
-                return testList;
-            }
+        /// <summary>
+        /// During testing, this is the first function that will be called for each TestCase.
+        /// This is run exactly once for this type.
+        /// </summary>
+        virtual void ClassSetUp()
+        {
+        }
 
-            /// <summary>
-            /// During testing, this is the first function that will be called for each TestCase.
-            /// This is run exactly once for this type.
-            /// </summary>
-            virtual void ClassSetUp()
-            {
-            }
+        /// <summary>
+        /// During testing, this will be called once before every test function.
+        /// This is run once for each test.
+        /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
+        /// </summary>
+        virtual void SetUp(TestContext& /*testContext*/)
+        {
+        }
 
-            /// <summary>
-            /// During testing, this will be called once before every test function.
-            /// This is run once for each test.
-            /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
-            /// </summary>
-            virtual void SetUp(TestContext& /*testContext*/)
-            {
-            }
+        /// <summary>
+        /// During testing, this will be called every tick that a test is asynchronous.
+        /// This is run every tick until testContext.EndTest() is called, or until the test times out.
+        /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
+        /// </summary>
+        virtual void Tick(TestContext& /*testContext*/) = 0;
 
-            /// <summary>
-            /// During testing, this will be called every tick that a test is asynchronous.
-            /// This is run every tick until testContext.EndTest() is called, or until the test times out.
-            /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
-            /// </summary>
-            virtual void Tick(TestContext& /*testContext*/) = 0;
+        /// <summary>
+        /// During testing, this will be called once after every test function.
+        /// This is run once for each test.
+        /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
+        /// </summary>
+        virtual void TearDown(TestContext& /*testContext*/)
+        {
+        }
 
-            /// <summary>
-            /// During testing, this will be called once after every test function.
-            /// This is run once for each test.
-            /// This is considered part of the active test. A failure or exception in this method will be considered a failure for the active test.
-            /// </summary>
-            virtual void TearDown(TestContext& /*testContext*/)
-            {
-            }
+        /// <summary>
+        /// During testing, this is the last function that will be called for each TestCase.
+        /// This is run exactly once for this type.
+        /// It is not considered part of any test. A failure or exception in this method will halt the test framework.
+        /// </summary>
+        virtual void ClassTearDown()
+        {
+        }
 
-            /// <summary>
-            /// During testing, this is the last function that will be called for each TestCase.
-            /// This is run exactly once for this type.
-            /// It is not considered part of any test. A failure or exception in this method will halt the test framework.
-            /// </summary>
-            virtual void ClassTearDown()
-            {
-            }
+    protected:
+        /// <summary>
+        /// Before testing, this function is called to gather the list of tests to run for each TestCase.
+        /// It is not considered part of any test.
+        /// <summary>
+        virtual void AddTests() = 0;
 
-        protected:
-            /// <summary>
-            /// Before testing, this function is called to gather the list of tests to run for each TestCase.
-            /// It is not considered part of any test.
-            /// <summary>
-            virtual void AddTests() = 0;
+        template <class T> void AddTest(std::string name, void(T::* testCaseFunc)(TestContext&))
+        {
+            T* testCase = reinterpret_cast<T*>(this);
+            const auto& testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);
+            std::shared_ptr<TestContext> testContext = std::make_shared<TestContext>(testCase, name, testFunc);
 
-            template <class T> void AddTest(std::string name, void(T::*testCaseFunc)(TestContext&))
-            {
-                T* testCase = reinterpret_cast<T*>(this);
-                const auto& testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);
-                std::shared_ptr<TestContext*> testContext = std::make_shared<TestContext*>(new TestContext(testCase, name, testFunc));
+            testList->push_back(testContext);
+        }
 
-                (*testList)->push_back(testContext);
-            }
-
-        private:
-            std::shared_ptr<TestList*> testList;
+    private:
+        std::shared_ptr<TestList> testList;
     };
 
     class PlayFabApiTestCase : public TestCase

--- a/source/test/TestApp/TestContext.cpp
+++ b/source/test/TestApp/TestContext.cpp
@@ -112,7 +112,7 @@ namespace PlayFabUnit
         {
             message = "fail";
         }
-        
+
         EndTest(TestFinishState::FAILED, message);
         // TODO: Throw "assert" exception
     }

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -34,9 +34,9 @@ namespace PlayFabUnit
         json["testResults"].swapPayload(init);
 
         int testResultIndex = 0;
-        for (auto it = testResults.begin(); it != testResults.end(); ++it)
+        for (auto testResult : testResults)
         {
-            (**it)->ToJson(json["testResults"][testResultIndex]);
+            testResult->ToJson(json["testResults"][testResultIndex]);
             testResultIndex += 1;
         }
     }
@@ -60,10 +60,8 @@ namespace PlayFabUnit
     void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message)
     {
         // Add a new TestCaseReport for the completed test.
-        TestCaseReport* testReport = new TestCaseReport();
-
-        std::shared_ptr<TestCaseReport*> testReportPtr = std::make_shared<TestCaseReport*>(testReport);
-        internalReport.testResults.push_back(testReportPtr);
+        std::shared_ptr<TestCaseReport> testReport = std::make_shared<TestCaseReport>();
+        internalReport.testResults.push_back(testReport);
 
         testReport->classname = internalReport.name;
         testReport->name = testName;

--- a/source/test/TestApp/TestReport.h
+++ b/source/test/TestApp/TestReport.h
@@ -18,18 +18,18 @@ namespace PlayFabUnit
     /// </summary>
     class TestCaseReport
     {
-        public:
-            std::string classname; // suite class name
-            std::string name; // test name
-            double time; // Duration in seconds
-            // Sub-Fields in the XML spec
-            /// <summary> message is the descriptive text used to debug the test failure </summary>
-            std::string message;
-            /// <summary> The xml spec allows failureText to be an arbitrary string.  When possible it should match FinishState (But not required) </summary>
-            std::string failureText;
-            TestFinishState finishState;
+    public:
+        std::string classname; // suite class name
+        std::string name; // test name
+        double time; // Duration in seconds
+        // Sub-Fields in the XML spec
+        /// <summary> message is the descriptive text used to debug the test failure </summary>
+        std::string message;
+        /// <summary> The xml spec allows failureText to be an arbitrary string.  When possible it should match FinishState (But not required) </summary>
+        std::string failureText;
+        TestFinishState finishState;
 
-            void ToJson(Json::Value& json);
+        void ToJson(Json::Value& json);
     };
 
     /// <summary>
@@ -37,32 +37,32 @@ namespace PlayFabUnit
     /// </summary>
     class TestSuiteReport
     {
-        public:
-            std::string name = "default"; // suite class name
-            int tests; // total test count
-            int failures; // count tests in state
-            int errors; // count tests in state
-            int skipped; // count tests in state
-            double time; // Duration in seconds
-            PlayFab::TimePoint timeStamp;
-            // Useful for debugging but not part of the serialized format
-            int passed; // Could be calculated from the others, but sometimes knowing if they don't add up means something
-            std::list<std::shared_ptr<TestCaseReport*>> testResults;
+    public:
+        std::string name = "default"; // suite class name
+        int tests; // total test count
+        int failures; // count tests in state
+        int errors; // count tests in state
+        int skipped; // count tests in state
+        double time; // Duration in seconds
+        PlayFab::TimePoint timeStamp;
+        // Useful for debugging but not part of the serialized format
+        int passed; // Could be calculated from the others, but sometimes knowing if they don't add up means something
+        std::list<std::shared_ptr<TestCaseReport>> testResults;
 
-            void ToJson(Json::Value& json);
+        void ToJson(Json::Value& json);
     };
 
     class TestReport
     {
-        public:
-            TestSuiteReport internalReport;
+    public:
+        TestSuiteReport internalReport;
 
-            TestReport(std::string testName);
+        TestReport(std::string testName);
 
-            void TestStarted();
+        void TestStarted();
 
-            void TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message);
+        void TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message);
 
-            bool AllTestsPassed();
+        bool AllTestsPassed();
     };
 }

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -28,8 +28,8 @@ namespace PlayFabUnit
         }
 
         // Add the tests from the given test case.
-        std::shared_ptr<TestList*> testCaseTests = testCase.GetTests();
-        suiteTests.splice(suiteTests.end(), **testCaseTests);
+        std::shared_ptr<TestList> testCaseTests = testCase.GetTests();
+        suiteTests.splice(suiteTests.end(), *testCaseTests);
     }
 
     void TestRunner::Run()
@@ -41,11 +41,8 @@ namespace PlayFabUnit
         }
 
         // Run the tests.
-        for (auto& suiteTest : suiteTests)
+        for (auto& test : suiteTests)
         {
-            // Get the next test.
-            TestContext* test = *suiteTest;
-
             // Handle transitions between TestCases.
             ManageTestCase(test->testCase, suiteTestCase);
 
@@ -112,10 +109,8 @@ namespace PlayFabUnit
         PlayFab::TimePoint testStartTime, testEndTime;
         size_t testsFinishedCount = 0, testsPassedCount = 0, testsFailedCount = 0, testsSkippedCount = 0;
 
-        for (auto testIter = suiteTests.begin(); testIter != suiteTests.end(); ++testIter)
+        for (auto& test : suiteTests)
         {
-            TestContext* test = **testIter;
-
             // Count tests
             if (TestActiveState::COMPLETE == test->activeState)
             {
@@ -144,11 +139,6 @@ namespace PlayFabUnit
             }
 
             // Line for each test report
-            if (suiteTests.begin() != testIter)
-            {
-                summaryStream << "\n";
-            }
-
             auto testDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(test->endTime - test->startTime);
             summaryStream << std::setw(10) << testDurationMs.count() << " ms";
             summaryStream << " - " << ToString(test->finishState);
@@ -157,9 +147,10 @@ namespace PlayFabUnit
             {
                 summaryStream << " - " << test->testResultMsg;
             }
+            summaryStream << "\n";
         }
 
-        summaryStream << "\n Testing complete:  ";
+        summaryStream << " - Testing complete:  ";
         summaryStream << testsFinishedCount << "/" << suiteTests.size() << " tests run, ";
         summaryStream << testsPassedCount << " tests passed, ";
         summaryStream << testsFailedCount << " tests failed, ";

--- a/source/test/TestApp/TestRunner.h
+++ b/source/test/TestApp/TestRunner.h
@@ -14,25 +14,25 @@ namespace PlayFabUnit
 
     class TestRunner
     {
-        private:
-            TestActiveState suiteState;
-            TestCase* suiteTestCase;
-            std::list<std::shared_ptr<TestContext*>> suiteTests;
+    private:
+        TestActiveState suiteState;
+        TestCase* suiteTestCase;
+        std::list<std::shared_ptr<TestContext>> suiteTests;
 
-            void ManageTestCase(TestCase* newTestCase, TestCase* oldTestCase);
+        void ManageTestCase(TestCase* newTestCase, TestCase* oldTestCase);
 
-            std::string GenerateTestSummary();
+        std::string GenerateTestSummary();
 
-        public:
-            std::string suiteTestSummary;
-            TestReport suiteTestReport;
+    public:
+        std::string suiteTestSummary;
+        TestReport suiteTestReport;
 
-            TestRunner();
+        TestRunner();
 
-            void Add(TestCase& testCase);
+        void Add(TestCase& testCase);
 
-            void Run();
+        void Run();
 
-            bool AllTestsPassed();
+        bool AllTestsPassed();
     };
 }


### PR DESCRIPTION
Because that's a massive memory leak
(Destroying the pointer to an obj doesn't destroy the obj)

**Related fixes:**
Fix all the places where we were relying on that memory leak (Mostly tests)
Do NOT make shared_ptr's to an object whose life-cycle we don't control (TestContext)

**Related refactoring:**
Track the N'th event a little more carefully.
Removing all static fields from PlayFabEventTest

**Good practice and cleanliness refactoring:**
Remove all trailing spaces in all files in the project
Converting all shared_ptr(new Thing()) to make_shared()
Standardize spacing (vs ctrl+k+d)