### PR TITLE
Fix segfault on first response-handle on Android.

### DIFF
--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -388,6 +388,7 @@ namespace PlayFab
                     else
                     { // LOCK httpRequestMutex
                         std::unique_lock<std::mutex> lock(httpRequestMutex);
+                        this->requestingTask->impl = nullptr;
                         this->pendingResults.emplace_back(std::move(this->requestingTask));
                     } // UNLOCK httpRequestMutex
 


### PR DESCRIPTION
requestingTask is a shared_ptr<RequestTask>.  RequestTask has a
unique_ptr\<PlayFabAndroidHttpPlugin::RequestImpl\> impl.  RequestImpl has
a JNIEnv*.  It's invalid to hold onto a JNIEnv* _unless_ the programmer
guarantees that all uses of its value will be from the same thread.  I
think this means the same Java thread, but I'm not totally clear on that
from what I've read of Oracle's docs.

So, without this change, whenever pendingResults gets popped-- during
handling of results, such as in `Update()`-- `~RequestingTask()` results
in `~RequestImpl()` which results in
`jniEnv->functions->DeleteGlobalRef(httpRequestObject)`.  Which then
segfaults due to invalid use of the saved JNIEnv*.

Result-handling doesn't care about the RequestTask, RequestImpl,
HttpRequestObject, etc.  So just null-out/delete the RequestImpl before
allowing its RequestTask owner to move out toward another thread.