### PR TITLE
Event API Testing and fixing

### DIFF
--- a/source/code/include/playfab/PlayFabEvent.h
+++ b/source/code/include/playfab/PlayFabEvent.h
@@ -16,8 +16,8 @@ namespace PlayFab
     enum class PlayFabEventType
     {
         Default, // Default type (e.g. the one set by global configuration)
-        Lightweight, // Event is meant to bypass processing on the PlayFab server side and be sent instead directly to One Collector (1DS).
-        Heavyweight // Event is meant to be sent to the PlayFab server.
+        Lightweight, // WriteTelemetryEvents
+        Heavyweight // WriteEvents
     };
 
     /// <summary>

--- a/source/code/include/playfab/PlayFabEvent.h
+++ b/source/code/include/playfab/PlayFabEvent.h
@@ -16,8 +16,8 @@ namespace PlayFab
     enum class PlayFabEventType
     {
         Default, // Default type (e.g. the one set by global configuration)
-        Lightweight, // WriteTelemetryEvents
-        Heavyweight // WriteEvents
+        Lightweight, // Event will be sent using WriteTelemetryEvents method in EventsAPI
+        Heavyweight // Event will be sent using WriteEvents method in EventsAPI
     };
 
     /// <summary>

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -59,7 +59,7 @@ namespace PlayFabUnit
             ApiCallback(&PlayFabEventTest::OnErrorSharedCallback),
             &testContext);
     }
-    void PlayFabEventTest::OnLogin(const PlayFab::ClientModels::LoginResult& result, void* customData)
+    void PlayFabEventTest::OnLogin(const PlayFab::ClientModels::LoginResult& /*result*/, void* customData)
     {
         TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
@@ -322,7 +322,7 @@ namespace PlayFabUnit
         PlayFabSettings::ForgetAllCredentials();
     }
 
-    void PlayFabEventTest::SetUp(TestContext& testContext)
+    void PlayFabEventTest::SetUp(TestContext& /*testContext*/)
     {
         PlayFabSettings::staticSettings->titleId = testTitleData.titleId;
         // Reset event test values.

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -301,11 +301,13 @@ namespace PlayFabUnit
 
     void PlayFabEventTest::AddTests()
     {
+        AddTest("BasicLogin", &PlayFabEventTest::BasicLogin);
+
         // TODO: Fix whatever limitation causes this test to fail for these platforms
 #if !defined(PLAYFAB_PLATFORM_IOS) && !defined(PLAYFAB_PLATFORM_ANDROID) && !defined(PLAYFAB_PLATFORM_PLAYSTATION) && !defined(PLAYFAB_PLATFORM_SWITCH)
         AddTest("QosResultApi", &PlayFabEventTest::QosResultApi);
 #endif
-        AddTest("BasicLogin", &PlayFabEventTest::BasicLogin);
+
         AddTest("EventsApi", &PlayFabEventTest::EventsApi);
         AddTest("HeavyweightEvents", &PlayFabEventTest::HeavyweightEvents);
         AddTest("LightweightEvents", &PlayFabEventTest::LightweightEvents);

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -284,7 +284,7 @@ namespace PlayFabUnit
 
     void PlayFabEventTest::ManyThreadsLowEventsPerTest(TestContext& testContext)
     {
-        // NOTE: Some platforms have hard limits on the maximum number of threads (This number found to be experimentally safe)
+        // NOTE: Some platforms have hard limits on the maximum number of threads (this number found to be experimentally safe)
         eventTestContext = &testContext;
         uint32_t numThreads = 30;
         uint32_t numEventsPerThread = 2;

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -24,11 +24,16 @@ namespace PlayFabUnit
 {
     struct TestContext;
 
-    class PlayFabEventTest : public TestCase
+    class PlayFabEventTest : public PlayFabApiTestCase
     {
     private:
         /// QoS API
         void QosResultApi(TestContext& testContext);
+
+        // Initial Login
+        void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
+        void BasicLogin(TestContext& testContext);
+        void OnLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
 
         /// EVENTS API
         /// Test that sends heavyweight events as a whole batch.

--- a/source/test/TestApp/TestApp.cpp
+++ b/source/test/TestApp/TestApp.cpp
@@ -59,8 +59,8 @@ namespace PlayFabUnit
             return 1;
 
             // TODO: POPULATE THIS SECTION WITH REAL INFORMATION (or set up a testTitleData file, and set your PF_TEST_TITLE_DATA_JSON to the path for that file)
-            //testInputs.titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
-            //testInputs.userEmail = ""; // This is the email for a valid user (test tries to log into it with an invalid password, and verifies error result)
+            //testTitleData.titleId = ""; // The titleId for your title, found in the "Settings" section of PlayFab Game Manager
+            //testTitleData.userEmail = ""; // This is the email for a valid user (test tries to log into it with an invalid password, and verifies error result)
         }
 
         // Initialize the test runner/test data.
@@ -81,9 +81,10 @@ namespace PlayFabUnit
         testRunner.Add(platformSpecificTest);
 #endif
 
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION) && !defined(PLAYFAB_PLATFORM_SWITCH)
+#if !defined(PLAYFAB_PLATFORM_PLAYSTATION)
         // These tests don't work on all platforms atm
         PlayFabEventTest pfEventTest;
+        pfEventTest.SetTitleInfo(testTitleData);
         testRunner.Add(pfEventTest);
 #endif
 


### PR DESCRIPTION
Address platform specific thread limits
Fix some comments that are out of date
EventTests perform their own login, and better isolate test settings
These tests work on the Switch now, so removed that platform filter