### PR TITLE
Cleanup, and remove platform limitations on Event Tests

### DIFF
--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -62,7 +62,6 @@ namespace PlayFabUnit
         void GenericMultiThreadedTest(uint32_t pNumThreads, uint32_t pNumEventsPerThread);
 
         // State
-        bool loggedIn;
         TestContext* eventTestContext;
         const int eventEmitCount = 6;
         size_t eventBatchMax;

--- a/source/test/TestApp/TestApp.cpp
+++ b/source/test/TestApp/TestApp.cpp
@@ -81,12 +81,9 @@ namespace PlayFabUnit
         testRunner.Add(platformSpecificTest);
 #endif
 
-#if !defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        // These tests don't work on all platforms atm
         PlayFabEventTest pfEventTest;
         pfEventTest.SetTitleInfo(testTitleData);
         testRunner.Add(pfEventTest);
-#endif
 
         PlayFabTestMultiUserStatic pfMultiUserStaticTest;
         pfMultiUserStaticTest.SetTitleInfo(testTitleData);


### PR DESCRIPTION
The Event Tests have been fixed and tested on all platforms
Remove the restrictions on those tests
A bit of cleanup that was missed in a previous checkin