### PR TITLE
Time overhaul

### DIFF
--- a/source/code/include/playfab/PlayFabBaseModel.h
+++ b/source/code/include/playfab/PlayFabBaseModel.h
@@ -80,7 +80,7 @@ namespace PlayFab
     // Utilities for [de]serializing time_t to/from json
     inline void ToJsonUtilT(const time_t input, Json::Value& output)
     {
-        output = Json::Value(LocalTimeTToUtcString(input));
+        output = Json::Value(TimeTToIso8601String(input));
     }
     inline void FromJsonUtilT(const Json::Value& input, time_t& output)
     {
@@ -88,7 +88,7 @@ namespace PlayFab
         {
             return;
         }
-        output = UtcStringToLocalTimeT(input.asString());
+        output = Iso8601StringToTimeT(input.asString());
     }
 
     inline void ToJsonUtilT(const Boxed<time_t>& input, Json::Value& output)

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -91,7 +91,7 @@ namespace PlayFab
         static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
 #else
         auto msClock = std::chrono::time_point_cast<std::chrono::milliseconds>(Clock::now());
-        return static_cast<Int64>(msClock.time_since_epoch().count());
+        return msClock.time_since_epoch().count();
 #endif
     }
 

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -39,7 +39,7 @@ namespace PlayFab
 
     inline tm TimeTToUtcTm(time_t input)
     {
-        tm timeInfo;
+        tm timeInfo{ 0 };
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         gmtime_s(&input, &timeInfo);
 #elif defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -104,7 +104,7 @@ namespace PlayFab
 
     inline tm Iso8601StringToTm(const std::string& utcString)
     {
-        tm timeInfo;
+        tm timeInfo{ 0 };
         std::istringstream iss(utcString);
         iss >> std::get_time(&timeInfo, TIMESTAMP_READ_FORMAT);
         return timeInfo;

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -17,6 +17,7 @@ namespace PlayFab
     // The primary purpose of these format strings is to communicate to and from the PlayFab server with consistent accuracy across platforms supported by this SDK
     constexpr char TIMESTAMP_READ_FORMAT[] = "%Y-%m-%dT%T";
     constexpr char TIMESTAMP_WRITE_FORMAT[] = "%Y-%m-%dT%H:%M:%S.000Z";
+    constexpr int TIMESTAMP_BUFFER_SIZE = 64; // Arbitrary number sufficiently large enough to contain the timestamp strings sent by PlayFab server
 
     // Initialize may be required on some platforms
     inline void InitializeClock()
@@ -97,8 +98,8 @@ namespace PlayFab
     // Time Serialization
     inline std::string UtcTmToIso8601String(const tm& input)
     {
-        char buff[64];
-        strftime(buff, 64, TIMESTAMP_WRITE_FORMAT, &input);
+        char buff[TIMESTAMP_BUFFER_SIZE];
+        strftime(buff, TIMESTAMP_BUFFER_SIZE, TIMESTAMP_WRITE_FORMAT, &input);
         return buff;
     }
 

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -40,7 +40,7 @@ namespace PlayFab
     inline tm TimeTToUtcTm(time_t input)
     {
         tm timeInfo;
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
 #define gmtime_r gmtime_s
 #endif
         gmtime_r(&input, &timeInfo);
@@ -49,10 +49,14 @@ namespace PlayFab
 
     inline time_t UtcTmToTimeT(tm input)
     {
+#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        return mktime(&input);
+#else
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
 #define timegm _mkgmtime
 #endif
         return timegm(&input);
+#endif
     }
 
     inline tm TimePointToUtcTm(TimePoint input)
@@ -84,7 +88,7 @@ namespace PlayFab
         static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
 #else
         auto msClock = std::chrono::time_point_cast<std::chrono::milliseconds>(Clock::now());
-        return msClock.time_since_epoch().count();
+        return static_cast<long>(msClock.time_since_epoch().count());
 #endif
     }
 

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -85,13 +85,13 @@ namespace PlayFab
     }
 
     // Get a tick count that represents now in milliseconds (not useful for absolute time)
-    inline long GetMilliTicks()
+    inline Int64 GetMilliTicks()
     {
 #if defined(PLAYFAB_PLATFORM_SWITCH)
         static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
 #else
         auto msClock = std::chrono::time_point_cast<std::chrono::milliseconds>(Clock::now());
-        return static_cast<long>(msClock.time_since_epoch().count());
+        return static_cast<Int64>(msClock.time_since_epoch().count());
 #endif
     }
 

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -7,53 +7,121 @@
 
 namespace PlayFab
 {
-    typedef std::chrono::time_point<std::chrono::system_clock> TimePoint;
+#if defined(PLAYFAB_PLATFORM_SWITCH)
+    static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
+#else
+    typedef std::chrono::system_clock Clock;
+    typedef std::chrono::time_point<Clock> TimePoint;
+#endif
 
-    inline TimePoint GetTimePointNow()
+    // The primary purpose of these format strings is to communicate to and from the PlayFab server with consistent accuracy across platforms supported by this SDK
+    constexpr char TIMESTAMP_READ_FORMAT[] = "%Y-%m-%dT%T";
+    constexpr char TIMESTAMP_WRITE_FORMAT[] = "%Y-%m-%dT%H:%M:%S.000Z";
+
+    // Initialize may be required on some platforms
+    inline void InitializeClock()
     {
-        return std::chrono::system_clock::now();
+#if defined(PLAYFAB_PLATFORM_SWITCH)
+        static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
+#endif
     }
 
-    inline time_t GetPlayFabTimeTNow()
+    // Time type conversions
+    inline time_t TimePointToTimeT(TimePoint input)
     {
-        return time(0);
+        return Clock::to_time_t(input);
     }
 
-    inline std::string LocalTimeTToUtcString(time_t now)
+    inline TimePoint TimeTToTimePoint(time_t input)
+    {
+        return Clock::from_time_t(input);
+    }
+
+    inline tm TimeTToUtcTm(time_t input)
     {
         tm timeInfo;
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
-        gmtime_s(&timeInfo, &now);
-#elif defined(PLAYFAB_PLATFORM_LINUX) || defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        timeInfo = *gmtime(&now);
+#define gmtime_r gmtime_s
 #endif
-        char buff[64];
-        strftime(buff, 64, "%Y-%m-%dT%H:%M:%S.000Z", &timeInfo);
+        gmtime_r(&input, &timeInfo);
+        return timeInfo;
+    }
 
+    inline time_t UtcTmToTimeT(tm input)
+    {
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+#define timegm _mkgmtime
+#endif
+        return timegm(&input);
+    }
+
+    inline tm TimePointToUtcTm(TimePoint input)
+    {
+        return TimeTToUtcTm(Clock::to_time_t(input));
+    }
+
+    inline TimePoint UtcTmToTimePoint(tm input)
+    {
+        return TimeTToTimePoint(UtcTmToTimeT(input));
+    }
+
+    // Get Time now - Platform dependent granularity (granularity: upto 1 second, accuracy within a few seconds)
+    inline TimePoint GetTimePointNow()
+    {
+        // The conversion is mostly to ensure consistent behavior among all platforms
+        return std::chrono::time_point_cast<std::chrono::seconds>(Clock::now());
+    }
+
+    inline time_t GetTimeTNow()
+    {
+        return TimePointToTimeT(GetTimePointNow());
+    }
+
+    // Get a tick count that represents now in milliseconds (not useful for absolute time)
+    inline long GetMilliTicks()
+    {
+#if defined(PLAYFAB_PLATFORM_SWITCH)
+        static_assert("You must request the Nintendo specific XPlat SDK from PlayFab support.");
+#else
+        auto msClock = std::chrono::time_point_cast<std::chrono::milliseconds>(Clock::now());
+        return msClock.time_since_epoch().count();
+#endif
+    }
+
+    // Time Serialization
+    inline std::string UtcTmToIso8601String(tm input)
+    {
+        char buff[64];
+        strftime(buff, 64, TIMESTAMP_WRITE_FORMAT, &input);
         return buff;
     }
 
-    inline std::string LocalTimePointToUtcString(TimePoint now)
+    inline tm Iso8601StringToTm(const std::string& utcString)
     {
-        return LocalTimeTToUtcString(std::chrono::system_clock::to_time_t(now));
+        tm timeInfo;
+        std::istringstream iss(utcString);
+        iss >> std::get_time(&timeInfo, TIMESTAMP_READ_FORMAT);
+        return timeInfo;
     }
 
-    inline time_t UtcStringToLocalTimeT(const std::string& utcString)
+    inline std::string TimeTToIso8601String(time_t input)
     {
-        time_t output;
-        tm timeStruct = {};
+        return UtcTmToIso8601String(TimeTToUtcTm(input));
+    }
 
-        std::istringstream iss(utcString);
-        iss >> std::get_time(&timeStruct, "%Y-%m-%dT%T");
-        timeStruct.tm_isdst = 0;  // 0 means "not in DST" PlayFab assumes UTC/Zulu always
-#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
-        output = mktime(&timeStruct);
-#elif defined(PLAYFAB_PLATFORM_IOS) || defined(PLAYFAB_PLATFORM_ANDROID) || defined(PLAYFAB_PLATFORM_LINUX)
-        gmtime_r(&output, &timeStruct);
-#else
-        output = _mkgmtime(&timeStruct);
-#endif
+    inline time_t Iso8601StringToTimeT(std::string input)
+    {
+        return UtcTmToTimeT(Iso8601StringToTm(input));
+    }
 
-        return output;
+    // TODO: Invert this conversion at some point, and serialize the milliseconds as well
+    inline std::string TimePointToIso8601String(TimePoint input)
+    {
+        return UtcTmToIso8601String(TimePointToUtcTm(input));
+    }
+
+    inline TimePoint Iso8601StringToTimePoint(std::string input)
+    {
+        return UtcTmToTimePoint(Iso8601StringToTm(input));
     }
 }

--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -40,10 +40,13 @@ namespace PlayFab
     inline tm TimeTToUtcTm(time_t input)
     {
         tm timeInfo;
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX) || defined(PLAYFAB_PLATFORM_PLAYSTATION)
-#define gmtime_r gmtime_s
-#endif
+#if defined(PLAYFAB_PLATFORM_PLAYSTATION)
+        gmtime_s(&input, &timeInfo);
+#elif defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+        gmtime_s(&timeInfo, &input);
+#else
         gmtime_r(&input, &timeInfo);
+#endif
         return timeInfo;
     }
 
@@ -51,10 +54,9 @@ namespace PlayFab
     {
 #if defined(PLAYFAB_PLATFORM_PLAYSTATION)
         return mktime(&input);
+#elif defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+        return _mkgmtime(&input);
 #else
-#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
-#define timegm _mkgmtime
-#endif
         return timegm(&input);
 #endif
     }
@@ -64,7 +66,7 @@ namespace PlayFab
         return TimeTToUtcTm(Clock::to_time_t(input));
     }
 
-    inline TimePoint UtcTmToTimePoint(tm input)
+    inline TimePoint UtcTmToTimePoint(const tm& input)
     {
         return TimeTToTimePoint(UtcTmToTimeT(input));
     }
@@ -93,7 +95,7 @@ namespace PlayFab
     }
 
     // Time Serialization
-    inline std::string UtcTmToIso8601String(tm input)
+    inline std::string UtcTmToIso8601String(const tm& input)
     {
         char buff[64];
         strftime(buff, 64, TIMESTAMP_WRITE_FORMAT, &input);
@@ -113,7 +115,7 @@ namespace PlayFab
         return UtcTmToIso8601String(TimeTToUtcTm(input));
     }
 
-    inline time_t Iso8601StringToTimeT(std::string input)
+    inline time_t Iso8601StringToTimeT(const std::string& input)
     {
         return UtcTmToTimeT(Iso8601StringToTm(input));
     }
@@ -124,7 +126,7 @@ namespace PlayFab
         return UtcTmToIso8601String(TimePointToUtcTm(input));
     }
 
-    inline TimePoint Iso8601StringToTimePoint(std::string input)
+    inline TimePoint Iso8601StringToTimePoint(const std::string& input)
     {
         return UtcTmToTimePoint(Iso8601StringToTm(input));
     }

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -256,7 +256,7 @@ namespace PlayFab
                 requestTask = std::make_shared<RequestTask>();
                 requestTask->Initialize(requestContainer);
             }
-            catch (const std::exception & ex)
+            catch (const std::exception& ex)
             {
                 PlayFabPluginManager::GetInstance().HandleException(ex);
             }

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -39,13 +39,9 @@ namespace PlayFabUnit
     }
 #endif
 
-    // Time out if waiting for login
-    constexpr int CLOUDSCRIPT_TIMEOUT_MS = 10000;
-    constexpr int CLOUDSCRIPT_TIMEOUT_INCREMENT = 100;
-
     void PlayFabEventTest::OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail(error.GenerateErrorReport());
     }
     void PlayFabEventTest::BasicLogin(TestContext& testContext)
@@ -104,13 +100,13 @@ namespace PlayFabUnit
 
     void PlayFabEventTest::OnEventsApiSucceeded(const PlayFab::EventsModels::WriteEventsResponse&, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Pass();
     }
 
     void PlayFabEventTest::OnEventsApiFailed(const PlayFab::PlayFabError& error, void* customData)
     {
-        TestContext* testContext = reinterpret_cast<TestContext*>(customData);
+        TestContext* testContext = static_cast<TestContext*>(customData);
         testContext->Fail(error.GenerateErrorReport());
     }
 

--- a/source/test/TestApp/TestApp.cpp
+++ b/source/test/TestApp/TestApp.cpp
@@ -81,9 +81,11 @@ namespace PlayFabUnit
         testRunner.Add(platformSpecificTest);
 #endif
 
+#if !defined(PLAYFAB_PLATFORM_SWITCH)
         PlayFabEventTest pfEventTest;
         pfEventTest.SetTitleInfo(testTitleData);
         testRunner.Add(pfEventTest);
+#endif
 
         PlayFabTestMultiUserStatic pfMultiUserStaticTest;
         pfMultiUserStaticTest.SetTitleInfo(testTitleData);
@@ -173,7 +175,7 @@ namespace PlayFabUnit
         cloudReportJson["testReport"].swapPayload(arrayInit);
 
         // Encode the test report as JSON.
-        TestReport* testReport = reinterpret_cast<TestReport*>(customData);
+        TestReport* testReport = static_cast<TestReport*>(customData);
         testReport->internalReport.ToJson(cloudReportJson["testReport"][0]);
 
         // Save the test results via cloud script.

--- a/source/test/TestApp/TestCase.h
+++ b/source/test/TestApp/TestCase.h
@@ -84,7 +84,7 @@ namespace PlayFabUnit
         /// <summary>
         virtual void AddTests() = 0;
 
-        template <class T> void AddTest(std::string name, void(T::* testCaseFunc)(TestContext&))
+        template <class T> void AddTest(const std::string& name, void(T::* testCaseFunc)(TestContext&))
         {
             T* testCase = static_cast<T*>(this);
             const auto& testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);

--- a/source/test/TestApp/TestCase.h
+++ b/source/test/TestApp/TestCase.h
@@ -86,7 +86,7 @@ namespace PlayFabUnit
 
         template <class T> void AddTest(std::string name, void(T::* testCaseFunc)(TestContext&))
         {
-            T* testCase = reinterpret_cast<T*>(this);
+            T* testCase = static_cast<T*>(this);
             const auto& testFunc = std::bind(testCaseFunc, testCase, std::placeholders::_1);
             std::shared_ptr<TestContext> testContext = std::make_shared<TestContext>(testCase, name, testFunc);
 

--- a/source/test/TestApp/TestContext.cpp
+++ b/source/test/TestApp/TestContext.cpp
@@ -6,7 +6,7 @@
 
 namespace PlayFabUnit
 {
-    void TestContext::EndTest(TestFinishState state, std::string resultMsg)
+    void TestContext::EndTest(TestFinishState state, const std::string& resultMsg)
     {
         if (finishState == TestFinishState::PENDING) // This means that we finish successfully
         {
@@ -101,7 +101,7 @@ namespace PlayFabUnit
         }
     }
 
-    void TestContext::Pass(std::string message)
+    void TestContext::Pass(const std::string& message)
     {
         EndTest(TestFinishState::PASSED, message);
     }
@@ -117,7 +117,7 @@ namespace PlayFabUnit
         // TODO: Throw "assert" exception
     }
 
-    void TestContext::Skip(std::string message)
+    void TestContext::Skip(const std::string& message)
     {
         EndTest(TestFinishState::SKIPPED, message);
         // TODO: Throw "test skipped" exception

--- a/source/test/TestApp/TestContext.cpp
+++ b/source/test/TestApp/TestContext.cpp
@@ -10,7 +10,7 @@ namespace PlayFabUnit
     {
         if (finishState == TestFinishState::PENDING) // This means that we finish successfully
         {
-            endTime = PlayFab::GetTimePointNow();
+            endTime = PlayFab::GetMilliTicks();
             testResultMsg = resultMsg;
             finishState = state;
             activeState = TestActiveState::READY;

--- a/source/test/TestApp/TestContext.h
+++ b/source/test/TestApp/TestContext.h
@@ -33,8 +33,8 @@ namespace PlayFabUnit
         std::string testResultMsg;
         TestFunc testFunc;
         TestCase* testCase;
-        PlayFab::TimePoint startTime;
-        PlayFab::TimePoint endTime;
+        long startTime;
+        long endTime;
 
         void EndTest(TestFinishState state, std::string resultMsg);
 

--- a/source/test/TestApp/TestContext.h
+++ b/source/test/TestApp/TestContext.h
@@ -17,7 +17,7 @@ namespace PlayFabUnit
 
     struct TestContext
     {
-        TestContext(TestCase* testCase, std::string name, TestFunc func) :
+        TestContext(TestCase* testCase, const std::string& name, TestFunc func) :
             testName(name),
             activeState(TestActiveState::PENDING),
             finishState(TestFinishState::PENDING),
@@ -36,10 +36,10 @@ namespace PlayFabUnit
         long startTime;
         long endTime;
 
-        void EndTest(TestFinishState state, std::string resultMsg);
+        void EndTest(TestFinishState state, const std::string& resultMsg);
 
-        void Pass(std::string message = "");
+        void Pass(const std::string& message = "");
         void Fail(std::string message = "");
-        void Skip(std::string message = "");
+        void Skip(const std::string& message = "");
     };
 }

--- a/source/test/TestApp/TestContext.h
+++ b/source/test/TestApp/TestContext.h
@@ -33,8 +33,8 @@ namespace PlayFabUnit
         std::string testResultMsg;
         TestFunc testFunc;
         TestCase* testCase;
-        long startTime;
-        long endTime;
+        Int64 startTime;
+        Int64 endTime;
 
         void EndTest(TestFinishState state, const std::string& resultMsg);
 

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -28,7 +28,6 @@ namespace PlayFabUnit
         json["errors"] = errors;
         json["skipped"] = skipped;
         json["time"] = time;
-        json["timestamp"] = PlayFab::LocalTimePointToUtcString(timeStamp);
         json["testResults"];
         Json::Value init(Json::arrayValue);
         json["testResults"].swapPayload(init);
@@ -44,7 +43,7 @@ namespace PlayFabUnit
     TestReport::TestReport(std::string className)
     {
         internalReport.name = className;
-        internalReport.timeStamp = PlayFab::GetTimePointNow();
+        internalReport.timeStamp = PlayFab::GetMilliTicks();
         internalReport.tests = 0;
         internalReport.failures = 0;
         internalReport.errors = 0;
@@ -57,7 +56,7 @@ namespace PlayFabUnit
         internalReport.tests += 1;
     }
 
-    void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message)
+    void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, long testDurationMs, std::string message)
     {
         // Add a new TestCaseReport for the completed test.
         std::shared_ptr<TestCaseReport> testReport = std::make_shared<TestCaseReport>();
@@ -86,7 +85,7 @@ namespace PlayFabUnit
 
         // Update overall runtime.
         // TODO: Add hooks for SuiteSetUp and SuiteTearDown, so this can be estimated more accurately
-        internalReport.time = std::chrono::duration<double>(PlayFab::GetTimePointNow() - internalReport.timeStamp).count(); // For now, update the duration on every test complete - the last one will be essentially correct
+        internalReport.time = PlayFab::GetMilliTicks() - internalReport.timeStamp; // For now, update the duration on every test complete - the last one will be essentially correct
     }
 
     bool TestReport::AllTestsPassed()

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -56,7 +56,7 @@ namespace PlayFabUnit
         internalReport.tests += 1;
     }
 
-    void TestReport::TestComplete(const std::string& testName, TestFinishState testFinishState, long testDurationMs, std::string message)
+    void TestReport::TestComplete(const std::string& testName, TestFinishState testFinishState, Int64 testDurationMs, std::string message)
     {
         // Add a new TestCaseReport for the completed test.
         std::shared_ptr<TestCaseReport> testReport = std::make_shared<TestCaseReport>();

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -40,7 +40,7 @@ namespace PlayFabUnit
         }
     }
 
-    TestReport::TestReport(std::string className)
+    TestReport::TestReport(const std::string& className)
     {
         internalReport.name = className;
         internalReport.timeStamp = PlayFab::GetMilliTicks();
@@ -56,7 +56,7 @@ namespace PlayFabUnit
         internalReport.tests += 1;
     }
 
-    void TestReport::TestComplete(std::string testName, TestFinishState testFinishState, long testDurationMs, std::string message)
+    void TestReport::TestComplete(const std::string& testName, TestFinishState testFinishState, long testDurationMs, std::string message)
     {
         // Add a new TestCaseReport for the completed test.
         std::shared_ptr<TestCaseReport> testReport = std::make_shared<TestCaseReport>();

--- a/source/test/TestApp/TestReport.cpp
+++ b/source/test/TestApp/TestReport.cpp
@@ -85,7 +85,7 @@ namespace PlayFabUnit
 
         // Update overall runtime.
         // TODO: Add hooks for SuiteSetUp and SuiteTearDown, so this can be estimated more accurately
-        internalReport.time = PlayFab::GetMilliTicks() - internalReport.timeStamp; // For now, update the duration on every test complete - the last one will be essentially correct
+        internalReport.time = (PlayFab::GetMilliTicks() - internalReport.timeStamp) / 1000.0; // For now, update the duration on every test complete - the last one will be essentially correct
     }
 
     bool TestReport::AllTestsPassed()

--- a/source/test/TestApp/TestReport.h
+++ b/source/test/TestApp/TestReport.h
@@ -57,11 +57,11 @@ namespace PlayFabUnit
     public:
         TestSuiteReport internalReport;
 
-        TestReport(std::string testName);
+        TestReport(const std::string& testName);
 
         void TestStarted();
 
-        void TestComplete(std::string testName, TestFinishState testFinishState, long testDurationMs, std::string message);
+        void TestComplete(const std::string& testName, TestFinishState testFinishState, long testDurationMs, std::string message);
 
         bool AllTestsPassed();
     };

--- a/source/test/TestApp/TestReport.h
+++ b/source/test/TestApp/TestReport.h
@@ -45,7 +45,7 @@ namespace PlayFabUnit
         int skipped; // count tests in state
         double time; // Duration in seconds
         // Useful for debugging but not part of the serialized format
-        long timeStamp;
+        Int64 timeStamp;
         int passed; // Could be calculated from the others, but sometimes knowing if they don't add up means something
         std::list<std::shared_ptr<TestCaseReport>> testResults;
 
@@ -61,7 +61,7 @@ namespace PlayFabUnit
 
         void TestStarted();
 
-        void TestComplete(const std::string& testName, TestFinishState testFinishState, long testDurationMs, std::string message);
+        void TestComplete(const std::string& testName, TestFinishState testFinishState, Int64 testDurationMs, std::string message);
 
         bool AllTestsPassed();
     };

--- a/source/test/TestApp/TestReport.h
+++ b/source/test/TestApp/TestReport.h
@@ -44,8 +44,8 @@ namespace PlayFabUnit
         int errors; // count tests in state
         int skipped; // count tests in state
         double time; // Duration in seconds
-        PlayFab::TimePoint timeStamp;
         // Useful for debugging but not part of the serialized format
+        long timeStamp;
         int passed; // Could be calculated from the others, but sometimes knowing if they don't add up means something
         std::list<std::shared_ptr<TestCaseReport>> testResults;
 
@@ -61,7 +61,7 @@ namespace PlayFabUnit
 
         void TestStarted();
 
-        void TestComplete(std::string testName, TestFinishState testFinishState, std::chrono::milliseconds testDurationMs, std::string message);
+        void TestComplete(std::string testName, TestFinishState testFinishState, long testDurationMs, std::string message);
 
         bool AllTestsPassed();
     };

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -10,7 +10,7 @@
 
 namespace PlayFabUnit
 {
-    static const long TEST_TIMEOUT_MILLISECONDS = 15000;
+    static const Int64 TEST_TIMEOUT_MILLISECONDS = 15000;
 
     TestRunner::TestRunner() :
         suiteState(TestActiveState::PENDING),
@@ -60,7 +60,7 @@ namespace PlayFabUnit
             // Tick the test.
             while (TestActiveState::ACTIVE == test->activeState)
             {
-                long timeNow = PlayFab::GetMilliTicks();
+                Int64 timeNow = PlayFab::GetMilliTicks();
                 bool timeExpired = (timeNow - test->startTime) > TEST_TIMEOUT_MILLISECONDS;
 
                 if ((TestActiveState::READY != test->activeState) && !timeExpired) // Not finished & not timed out
@@ -87,7 +87,7 @@ namespace PlayFabUnit
             test->activeState = TestActiveState::COMPLETE;
 
             // Update the report.
-            long testDurationMs = test->endTime - test->startTime;
+            Int64 testDurationMs = test->endTime - test->startTime;
             suiteTestReport.TestComplete(test->testName, test->finishState, testDurationMs, test->testResultMsg);
         }
 
@@ -105,8 +105,8 @@ namespace PlayFabUnit
     {
         std::stringstream summaryStream;
 
-        long timeNow = PlayFab::GetMilliTicks();
-        long testStartTime, testEndTime;
+        Int64 timeNow = PlayFab::GetMilliTicks();
+        Int64 testStartTime, testEndTime;
         size_t testsFinishedCount = 0, testsPassedCount = 0, testsFailedCount = 0, testsSkippedCount = 0;
 
         for (auto& test : suiteTests)
@@ -139,7 +139,7 @@ namespace PlayFabUnit
             }
 
             // Line for each test report
-            long testDurationMs = test->endTime - test->startTime;
+            Int64 testDurationMs = test->endTime - test->startTime;
             summaryStream << std::setw(10) << testDurationMs << " ms";
             summaryStream << " - " << ToString(test->finishState);
             summaryStream << " - " << test->testName;

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -10,7 +10,7 @@
 
 namespace PlayFabUnit
 {
-    static const auto TEST_TIMEOUT_DURATION = std::chrono::seconds(15);
+    static const long TEST_TIMEOUT_MILLISECONDS = 15000;
 
     TestRunner::TestRunner() :
         suiteState(TestActiveState::PENDING),
@@ -47,7 +47,7 @@ namespace PlayFabUnit
             ManageTestCase(test->testCase, suiteTestCase);
 
             // Start the test.
-            test->startTime = PlayFab::GetTimePointNow();
+            test->startTime = PlayFab::GetMilliTicks();
             test->activeState = TestActiveState::ACTIVE;
             suiteTestReport.TestStarted();
 
@@ -60,8 +60,8 @@ namespace PlayFabUnit
             // Tick the test.
             while (TestActiveState::ACTIVE == test->activeState)
             {
-                PlayFab::TimePoint timeNow = PlayFab::GetTimePointNow();
-                bool timeExpired = (timeNow - test->startTime) > TEST_TIMEOUT_DURATION;
+                long timeNow = PlayFab::GetMilliTicks();
+                bool timeExpired = (timeNow - test->startTime) > TEST_TIMEOUT_MILLISECONDS;
 
                 if ((TestActiveState::READY != test->activeState) && !timeExpired) // Not finished & not timed out
                 {
@@ -82,12 +82,12 @@ namespace PlayFabUnit
             }
 
             // Tear down the test.
-            test->endTime = PlayFab::GetTimePointNow();
+            test->endTime = PlayFab::GetMilliTicks();
             test->testCase->TearDown(*test);
             test->activeState = TestActiveState::COMPLETE;
 
             // Update the report.
-            auto testDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(test->endTime - test->startTime);
+            long testDurationMs = test->endTime - test->startTime;
             suiteTestReport.TestComplete(test->testName, test->finishState, testDurationMs, test->testResultMsg);
         }
 
@@ -105,8 +105,8 @@ namespace PlayFabUnit
     {
         std::stringstream summaryStream;
 
-        PlayFab::TimePoint timeNow = PlayFab::GetTimePointNow();
-        PlayFab::TimePoint testStartTime, testEndTime;
+        long timeNow = PlayFab::GetMilliTicks();
+        long testStartTime, testEndTime;
         size_t testsFinishedCount = 0, testsPassedCount = 0, testsFailedCount = 0, testsSkippedCount = 0;
 
         for (auto& test : suiteTests)
@@ -139,8 +139,8 @@ namespace PlayFabUnit
             }
 
             // Line for each test report
-            auto testDurationMs = std::chrono::duration_cast<std::chrono::milliseconds>(test->endTime - test->startTime);
-            summaryStream << std::setw(10) << testDurationMs.count() << " ms";
+            long testDurationMs = test->endTime - test->startTime;
+            summaryStream << std::setw(10) << testDurationMs << " ms";
             summaryStream << " - " << ToString(test->finishState);
             summaryStream << " - " << test->testName;
             if (!test->testResultMsg.empty())


### PR DESCRIPTION
Some platforms have feature limitations when it comes to time, so we separate into distinct needs:

- The ability to accurately measure a duration
- The ability to serialize UTC timestamps to/from PlayFab
- Multi-Thread compatible conversion funcs in all time related code
- Consistency between PlayFab server time and local device time (as UTC timezone), with a properly configured device

Fixed (often unrelated) some reinterpret_casts to static_casts when applicable
Updated the utilization of the feature-appropriate-timestamp-methods where needed (mostly test framework)
GetServerTime now outputs the local interpretation of the server time (for additional human verification)
GetServerTime now tests a range of "suspicious" outputs with the deserialized Server Time (basically check that it's not 1970)
And good descriptive and highly accurate names for all the methods.
A full set of conversion functions for useful utility.