### PR TITLE
Minor fixes and more work on EventTests

### DIFF
--- a/source/code/include/playfab/PlayFabPlatformUtils.h
+++ b/source/code/include/playfab/PlayFabPlatformUtils.h
@@ -28,7 +28,7 @@ namespace PlayFab
     }
 
     // Time type conversions
-    inline time_t TimePointToTimeT(TimePoint input)
+    inline time_t TimePointToTimeT(const TimePoint& input)
     {
         return Clock::to_time_t(input);
     }
@@ -62,7 +62,7 @@ namespace PlayFab
 #endif
     }
 
-    inline tm TimePointToUtcTm(TimePoint input)
+    inline tm TimePointToUtcTm(const TimePoint& input)
     {
         return TimeTToUtcTm(Clock::to_time_t(input));
     }
@@ -122,7 +122,7 @@ namespace PlayFab
     }
 
     // TODO: Invert this conversion at some point, and serialize the milliseconds as well
-    inline std::string TimePointToIso8601String(TimePoint input)
+    inline std::string TimePointToIso8601String(const TimePoint& input)
     {
         return UtcTmToIso8601String(TimePointToUtcTm(input));
     }

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -24,6 +24,13 @@ namespace PlayFabUnit
 {
     struct TestContext;
 
+    // A wrapper around TestEvents, so we can track it back to the test that launched the event
+    class TestEvent : public PlayFab::PlayFabEvent
+    {
+    public:
+        TestContext* testContext;
+    };
+
     class PlayFabEventTest : public PlayFabApiTestCase
     {
     private:
@@ -59,10 +66,9 @@ namespace PlayFabUnit
         void ManyThreadsLowEventsPerTest(TestContext& testContext);
         void FewThreadsHighEventsPerTest(TestContext& testContext);
 
-        void GenericMultiThreadedTest(uint32_t pNumThreads, uint32_t pNumEventsPerThread);
+        void GenericMultiThreadedTest(TestContext& testContext, uint32_t pNumThreads, uint32_t pNumEventsPerThread);
 
         // State
-        TestContext* eventTestContext;
         const int eventEmitCount = 6;
         size_t eventBatchMax;
         int eventPassCount;
@@ -73,7 +79,7 @@ namespace PlayFabUnit
         std::atomic<uint32_t> eventCounter;
 
         // Utility
-        void EmitEvents(PlayFab::PlayFabEventType eventType, int maxBatchWaitTime = 2, int maxItemsInBatch = 3, int maxBatchesInFlight = 10);
+        void EmitEvents(TestContext& testContext, PlayFab::PlayFabEventType eventType, int maxBatchWaitTime = 2, int maxItemsInBatch = 3, int maxBatchesInFlight = 10);
         void EmitEventCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response);
         void NonStaticEmitEventCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response);
 
@@ -87,7 +93,7 @@ namespace PlayFabUnit
         }
 
         std::shared_ptr<PlayFab::PlayFabEventAPI> SetupEventTest(int maxBatchWaitTime = 2, int maxItemSinBatch = 3, int maxBatchesInFlight = 10);
-        std::unique_ptr<PlayFab::PlayFabEvent> MakeEvent(PlayFab::PlayFabEventType eventType);
+        std::unique_ptr<PlayFab::PlayFabEvent> MakeEvent(TestContext& testContext, PlayFab::PlayFabEventType eventType);
 
     protected:
         void AddTests() override;

--- a/source/test/TestApp/TestApp.h
+++ b/source/test/TestApp/TestApp.h
@@ -2,8 +2,11 @@
 
 #pragma once
 
-#include <string>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <string>
+
 #include "TestDataTypes.h"
 
 namespace PlayFab
@@ -30,6 +33,9 @@ namespace PlayFabUnit
         // Cloud Report
         std::string cloudResponse = "";
         std::string cloudPlayFabId = "";
+        std::mutex cloudResponseMutex;
+        std::condition_variable cloudResponseConditionVar;
+
         void OnPostReportLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
         void OnPostReportComplete(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* /*customData*/);
         void OnPostReportError(const PlayFab::PlayFabError& error, void* /*customData*/);

--- a/source/test/TestApp/TestContext.h
+++ b/source/test/TestApp/TestContext.h
@@ -31,15 +31,23 @@ namespace PlayFabUnit
         TestActiveState activeState;
         TestFinishState finishState;
         std::string testResultMsg;
+        std::string interrimMsg;
         TestFunc testFunc;
         TestCase* testCase;
         Int64 startTime;
         Int64 endTime;
 
+        // End this test with the given state and message
         void EndTest(TestFinishState state, const std::string& resultMsg);
 
+        // End this test with PASSED state and optional message
         void Pass(const std::string& message = "");
-        void Fail(std::string message = "");
+        // End this test with FAILED state and optional message
+        void Fail(const std::string& message = "");
+        // End this test with SKIPPED state and optional message
         void Skip(const std::string& message = "");
+
+        // Set a temporary message, which will display if the test times out
+        void SetInterrimMessage(const std::string& message);
     };
 }

--- a/source/test/TestApp/TestDataTypes.h
+++ b/source/test/TestApp/TestDataTypes.h
@@ -18,7 +18,7 @@ namespace PlayFabUnit
     {
         PENDING, // Not started
         ACTIVE, // Currently testing
-        READY, // An answer is sent by the http thread, but the main thread hasn't finalized the test yet
+        READY, // An answer is sent by the (potentially) alternate thread, but the main thread hasn't finalized the test yet
         COMPLETE, // Test is finalized and recorded
         ABORTED // todo
     };
@@ -31,4 +31,5 @@ namespace PlayFabUnit
         SKIPPED,
         TIMEDOUT
     };
+    static const char* TestFinishStateToString[] = { "PENDING", "PASSED", "FAILED", "SKIPPED", "TIMEDOUT" };
 }

--- a/source/test/TestApp/TestRunner.cpp
+++ b/source/test/TestApp/TestRunner.cpp
@@ -85,6 +85,7 @@ namespace PlayFabUnit
             test->endTime = PlayFab::GetMilliTicks();
             test->testCase->TearDown(*test);
             test->activeState = TestActiveState::COMPLETE;
+            // printf("\n%s\n", suiteTestSummary.c_str()); // If we're debugging EventTests, it's nice to see each test as it happens...
 
             // Update the report.
             Int64 testDurationMs = test->endTime - test->startTime;
@@ -139,7 +140,7 @@ namespace PlayFabUnit
             }
 
             // Line for each test report
-            Int64 testDurationMs = test->endTime - test->startTime;
+            Int64 testDurationMs = testEndTime - testStartTime;
             summaryStream << std::setw(10) << testDurationMs << " ms";
             summaryStream << " - " << ToString(test->finishState);
             summaryStream << " - " << test->testName;


### PR DESCRIPTION
We're back to flagging EventTests as totally disabled
While they are working great in debug for a high % of runs for all platforms, they're failing 100% in release mode.
This set of test changes addresses some of the issues I found in this pass of test debugging, mostly around crashes if the test duration exceeds maximum (which seems to be a release-mode issue...?).
It also addresses some trivial CR comments that came in after previous commits were landed.

Note, some added commented code, which is needed for further investigation of EventTests.
It's my opinion at this time, based on lots of analysis and debugging, that the event pipeline is in good shape, but the tests still need an enormous amount of work.