### PR TITLE
Remove unused formal parameters

### DIFF
--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -62,7 +62,7 @@ namespace PlayFab
         http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
     }
 
-    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int httpCode, const std::string& result, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
+    void PlayFab<%- api.name %>API::On<%- apiCall.name %>Result(int /*httpCode*/, const std::string& /*result*/, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
     {
         CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
         std::shared_ptr<PlayFabAuthenticationContext> context = container.GetContext();

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -137,7 +137,7 @@ namespace PlayFab
         http.MakePostRequest(std::unique_ptr<CallRequestContainerBase>(static_cast<CallRequestContainerBase*>(reqContainer.release())));
     }
 
-    void PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result(int httpCode, const std::string& result, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
+    void PlayFab<%- api.name %>InstanceAPI::On<%- apiCall.name %>Result(int /*httpCode*/, const std::string& /*result*/, const std::shared_ptr<CallRequestContainerBase>& reqContainer)
     {
         CallRequestContainer& container = static_cast<CallRequestContainer&>(*reqContainer);
         std::shared_ptr<PlayFabAuthenticationContext> context = container.GetContext();


### PR DESCRIPTION
We can still accept them as parameters to not break users. But this leads to thousands of warnings when compiling on the Xbox regarding the httpCode being unused and the string result as well.