### PR TITLE
Adding DISABLE_PLAYFAB_STATIC_API

### DIFF
--- a/source/build/Windows/TestClientApp.vcxproj.filters
+++ b/source/build/Windows/TestClientApp.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(TestSourceDir)\TestApp\TestAppPch.h">

--- a/source/build/Windows/TestServerApp.vcxproj.filters
+++ b/source/build/Windows/TestServerApp.vcxproj.filters
@@ -9,10 +9,6 @@
       <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
       <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
     </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="$(TestSourceDir)\TestApp\TestAppPch.h">

--- a/source/code/include/playfab/PlayFabAuthenticationContext.h
+++ b/source/code/include/playfab/PlayFabAuthenticationContext.h
@@ -9,7 +9,7 @@ namespace PlayFab
     /// </summary>
     class PlayFabAuthenticationContext
     {
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
     public: // Client-only variables should only be visible when appropriate
 #else
     private: // But, static library memory size and alloc issues mean it always needs to exist
@@ -36,5 +36,7 @@ namespace PlayFab
 
         void HandlePlayFabLogin(const std::string& _playFabId, const std::string& _clientSessionTicket, const std::string& _entityId, const std::string& _entityType, const std::string& _entityToken);
         void ForgetAllCredentials();
+        bool IsClientLoggedIn();
+        bool IsEntityLoggedIn();
     };
 }

--- a/source/code/include/playfab/PlayFabBaseModel.h
+++ b/source/code/include/playfab/PlayFabBaseModel.h
@@ -1,16 +1,14 @@
 #pragma once
 
-#include <assert.h>
-#include <functional>
-#include <list>
-#include <map>
-#include <memory>
-
 #include <playfab/PlayFabPlatformMacros.h>
 #include <playfab/PlayFabPlatformTypes.h>
 #include <playfab/PlayFabJsonHeaders.h>
 #include <playfab/PlayFabPlatformTypes.h>
 #include <playfab/PlayFabPlatformUtils.h>
+
+#include <assert.h>
+#include <functional>
+#include <list>
 
 namespace PlayFab
 {

--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -1,11 +1,12 @@
 #pragma once
 
-#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFabError.h>
 #include <playfab/PlayFabCallRequestContainerBase.h>
 
 namespace PlayFab
 {
+    class PlayFabApiSettings;
+
     /// <summary>
     /// Internal PlayFabHttp container for each API call
     /// </summary>

--- a/source/code/include/playfab/PlayFabCallRequestContainerBase.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainerBase.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <unordered_map>
-#include <memory>
-
 namespace PlayFab
 {
     class CallRequestContainerBase;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -7,10 +7,14 @@
 
 #include <playfab/PlayFabEvent.h>
 #include <playfab/PlayFabEventBuffer.h>
+
 #include <mutex>
+#include <unordered_map>
 
 namespace PlayFab
 {
+    class PlayFabEventsInstanceAPI;
+
     enum class PlayFabEventPipelineType
     {
         PlayFabPlayStream,
@@ -51,7 +55,7 @@ namespace PlayFab
     /// <summary>
     /// Implementation of PlayFab-specific event pipeline
     /// </summary>
-    class PlayFabEventPipeline: public IPlayFabEventPipeline
+    class PlayFabEventPipeline : public IPlayFabEventPipeline
     {
     public:
         explicit PlayFabEventPipeline(const std::shared_ptr<PlayFabEventPipelineSettings>& settings);
@@ -87,6 +91,8 @@ namespace PlayFab
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
+        std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
+
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
         PlayFabEventBuffer buffer;
         std::thread workerThread;

--- a/source/code/include/playfab/PlayFabEventRouter.h
+++ b/source/code/include/playfab/PlayFabEventRouter.h
@@ -2,8 +2,9 @@
 
 #ifndef DISABLE_PLAYFABENTITY_API
 
-#include <playfab/PlayFabEvent.h>
 #include <playfab/PlayFabEventPipeline.h>
+
+#include <unordered_map>
 
 namespace PlayFab
 {
@@ -33,7 +34,7 @@ namespace PlayFab
     /// <summary>
     /// Default implementation of event router
     /// </summary>
-    class PlayFabEventRouter: public IPlayFabEventRouter
+    class PlayFabEventRouter : public IPlayFabEventRouter
     {
     public:
         PlayFabEventRouter();

--- a/source/code/include/playfab/PlayFabSettings.h
+++ b/source/code/include/playfab/PlayFabSettings.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <playfab/PlayFabError.h>
-#include <playfab/PlayFabSettings.h>
-#include <playfab/PlayFabCallRequestContainer.h>
+//#include <playfab/PlayFabCallRequestContainer.h>
 
 namespace PlayFab
 {
+    class PlayFabApiSettings;
+    class PlayFabAuthenticationContext;
+
     /// <summary>
     /// All settings and global variables for PlayFab
     /// </summary>
@@ -27,7 +29,7 @@ namespace PlayFab
         static const std::shared_ptr<PlayFabApiSettings> staticSettings;
         static const std::shared_ptr<PlayFabAuthenticationContext> staticPlayer;
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         static const std::string AD_TYPE_IDFA;
         static const std::string AD_TYPE_ANDROID_ID;
 #endif

--- a/source/code/include/playfab/PlayFabSettings.h
+++ b/source/code/include/playfab/PlayFabSettings.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <playfab/PlayFabError.h>
-//#include <playfab/PlayFabCallRequestContainer.h>
 
 namespace PlayFab
 {

--- a/source/code/include/playfab/QoS/PlayFabQoSApi.h
+++ b/source/code/include/playfab/QoS/PlayFabQoSApi.h
@@ -1,22 +1,28 @@
 #pragma once
 
-#include <future>
-#include <chrono>
 
 #include <playfab/QoS/QoS.h>
 #include <playfab/QoS/QoSResult.h>
 #include <playfab/QoS/QoSSocket.h>
-#include <playfab/PlayFabMultiplayerDataModels.h>
 #include <playfab/PlayFabEventsDataModels.h>
 #include <playfab/PlayFabError.h>
 
+#include <chrono>
+#include <future>
+#include <unordered_map>
+
 namespace PlayFab
 {
+    class PlayFabEventsInstanceAPI;
+    class PlayFabMultiplayerInstanceAPI;
+
     namespace QoS
     {
         class PlayFabQoSApi
         {
         public:
+            PlayFabQoSApi();
+
             // Runs a QoS operation asynchronously. The operation pings a set of regions and returns a result with average response times.
             std::future<QoSResult> GetQoSResultAsync(unsigned int numThreads, unsigned int timeoutMs = DEFAULT_TIMEOUT_MS);
 
@@ -24,6 +30,9 @@ namespace PlayFab
             QoSResult GetQoSResult(unsigned int numThreads, unsigned int timeoutMs = DEFAULT_TIMEOUT_MS);
 
         private:
+            std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
+            std::shared_ptr<PlayFabMultiplayerInstanceAPI> multiplayerApi;
+
             std::vector<std::string> GetPingList(unsigned int serverCount);
             void InitializeAccumulatedPingResults(std::unordered_map<std::string, PingResult>& accumulatedPingResults);
             int SetupSockets(std::vector<std::shared_ptr<QoSSocket>>& sockets, unsigned int numThreads, unsigned int timeoutMs);

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp
@@ -1,7 +1,6 @@
 #include <stdafx.h>
 
 #include <playfab/PlayFabAuthenticationContext.h>
-#include <playfab/PlayFabSettings.h>
 
 namespace PlayFab
 {
@@ -12,7 +11,7 @@ namespace PlayFab
 
     void PlayFabAuthenticationContext::ForgetAllCredentials()
     {
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         playFabId.clear();
         clientSessionTicket.clear();
         advertisingIdType.clear();
@@ -44,5 +43,15 @@ namespace PlayFab
         SetIfNotNull(_entityId, entityId);
         SetIfNotNull(_entityType, entityType);
         SetIfNotNull(_entityToken, entityToken);
+    }
+
+    bool PlayFabAuthenticationContext::IsClientLoggedIn()
+    {
+        return !clientSessionTicket.empty();
+    }
+
+    bool PlayFabAuthenticationContext::IsEntityLoggedIn()
+    {
+        return !entityToken.empty();
     }
 }

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -220,7 +220,7 @@ namespace PlayFab
                 // give some time back to CPU, don't starve it without a good reason
                 std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime));
             }
-            catch (const std::exception & ex)
+            catch (const std::exception& ex)
             {
                 LOG_PIPELINE("An exception was caught in PlayFabEventPipeline::WorkerThread method");
                 this->isWorkerThreadRunning = false;

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -2,9 +2,11 @@
 
 #ifndef DISABLE_PLAYFABENTITY_API
 
-#include <chrono>
 #include <playfab/PlayFabEventPipeline.h>
-#include <playfab/PlayFabEventsApi.h>
+#include <playfab/PlayFabEventsInstanceApi.h>
+#include <playfab/PlayFabSettings.h>
+
+#include <chrono>
 
 namespace PlayFab
 {
@@ -40,6 +42,8 @@ namespace PlayFab
         buffer(settings->bufferSize),
         isWorkerThreadRunning(false)
     {
+        eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);
+
         this->settings = settings;
         this->batch.reserve(this->settings->maximalNumberOfItemsInBatch);
         this->batchesInFlight.reserve(this->settings->maximalNumberOfBatchesInFlight);
@@ -216,7 +220,7 @@ namespace PlayFab
                 // give some time back to CPU, don't starve it without a good reason
                 std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime));
             }
-            catch (const std::exception& ex)
+            catch (const std::exception & ex)
             {
                 LOG_PIPELINE("An exception was caught in PlayFabEventPipeline::WorkerThread method");
                 this->isWorkerThreadRunning = false;
@@ -261,7 +265,7 @@ namespace PlayFab
         if (this->settings->emitType == PlayFabEventPipelineType::PlayFabPlayStream)
         {
             // call Events API to send the batch
-            PlayFabEventsAPI::WriteEvents(
+            eventsApi->WriteEvents(
                 batchReq,
                 std::bind(&PlayFabEventPipeline::WriteEventsApiCallback, this, std::placeholders::_1, std::placeholders::_2),
                 std::bind(&PlayFabEventPipeline::WriteEventsApiErrorCallback, this, std::placeholders::_1, std::placeholders::_2),
@@ -270,7 +274,7 @@ namespace PlayFab
         else
         {
             // call Events API to send the batch, bypassing Playstream
-            PlayFabEventsAPI::WriteTelemetryEvents(
+            eventsApi->WriteTelemetryEvents(
                 batchReq,
                 std::bind(&PlayFabEventPipeline::WriteEventsApiCallback, this, std::placeholders::_1, std::placeholders::_2),
                 std::bind(&PlayFabEventPipeline::WriteEventsApiErrorCallback, this, std::placeholders::_1, std::placeholders::_2),

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -15,7 +15,7 @@ namespace PlayFab
     const std::shared_ptr<PlayFabApiSettings> PlayFabSettings::staticSettings = std::make_shared<PlayFabApiSettings>();
     const std::shared_ptr<PlayFabAuthenticationContext> PlayFabSettings::staticPlayer = std::make_shared<PlayFabAuthenticationContext>();
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
     const std::string PlayFabSettings::AD_TYPE_IDFA = "Idfa";
     const std::string PlayFabSettings::AD_TYPE_ANDROID_ID = "Adid";
 #endif

--- a/source/code/stdafx.h
+++ b/source/code/stdafx.h
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <string>

--- a/source/test/TestApp/PlayFabApiTest.h
+++ b/source/test/TestApp/PlayFabApiTest.h
@@ -2,9 +2,14 @@
 
 #pragma once
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
+
+#include <memory>
 
 #include <playfab/PlayFabPlatformUtils.h>
+#include <playfab/PlayFabAuthenticationInstanceApi.h>
+#include <playfab/PlayFabClientInstanceApi.h>
+#include <playfab/PlayFabDataInstanceApi.h>
 
 #include "TestCase.h"
 
@@ -45,6 +50,11 @@ namespace PlayFabUnit
     class PlayFabApiTest : public PlayFabApiTestCase
     {
     private:
+        // Api instances
+        std::shared_ptr<PlayFab::PlayFabAuthenticationInstanceAPI> authApi;
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
+        std::shared_ptr<PlayFab::PlayFabDataInstanceAPI> dataApi;
+
         // Fixed values provided from testInputs
         bool TITLE_INFO_SET;
         std::string USER_EMAIL;
@@ -52,9 +62,6 @@ namespace PlayFabUnit
         // Information fetched by appropriate API calls
         const static std::string TEST_DATA_KEY;
         const static std::string TEST_STAT_NAME;
-        std::string playFabId;
-        std::string entityId;
-        std::string entityType;
         int testMessageInt;
         PlayFab::TimePoint testMessageTime;
 

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -2,12 +2,14 @@
 
 #include "TestAppPch.h"
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include <thread>
 #include <chrono>
-#include <playfab/PlayFabClientApi.h>
-#include <playfab/PlayFabEventsApi.h>
+#include <playfab/PlayFabClientDataModels.h>
+#include <playfab/PlayFabClientInstanceApi.h>
+#include <playfab/PlayFabEventsDataModels.h>
+#include <playfab/PlayFabEventsInstanceApi.h>
 #include <playfab/PlayFabSettings.h>
 #include <playfab/QoS/PlayFabQoSApi.h>
 #include "PlayFabEventTest.h"
@@ -50,7 +52,7 @@ namespace PlayFabUnit
         request.CustomId = PlayFabSettings::buildIdentifier;
         request.CreateAccount = true;
 
-        PlayFabClientAPI::LoginWithCustomID(request,
+        clientApi->LoginWithCustomID(request,
             ApiCallback(&PlayFabEventTest::OnLogin),
             ApiCallback(&PlayFabEventTest::OnErrorSharedCallback),
             &testContext);
@@ -76,7 +78,7 @@ namespace PlayFabUnit
     }
     void PlayFabEventTest::EventsApi(TestContext& testContext)
     {
-        if (!PlayFabClientAPI::IsClientLoggedIn())
+        if (!PlayFabSettings::staticPlayer->IsClientLoggedIn())
         {
             testContext.Skip("Earlier tests failed to log in");
             return;
@@ -92,7 +94,7 @@ namespace PlayFabUnit
             request.Events.push_back(CreateEventContents("event_B_", i));
         }
 
-        PlayFabEventsAPI::WriteEvents(request,
+        eventsApi->WriteEvents(request,
             ApiCallback(&PlayFabEventTest::OnEventsApiSucceeded),
             ApiCallback(&PlayFabEventTest::OnEventsApiFailed),
             &testContext);
@@ -311,6 +313,9 @@ namespace PlayFabUnit
 
     void PlayFabEventTest::ClassSetUp()
     {
+        clientApi = std::make_shared<PlayFabClientInstanceAPI>(PlayFabSettings::staticPlayer);
+        eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);
+
         // Make sure PlayFab state is clean.
         PlayFabSettings::ForgetAllCredentials();
     }

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include <functional>
 #include <string>
@@ -34,6 +34,9 @@ namespace PlayFabUnit
     class PlayFabEventTest : public PlayFabApiTestCase
     {
     private:
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
+        std::shared_ptr<PlayFab::PlayFabEventsInstanceAPI> eventsApi;
+
         /// QoS API
         void QosResultApi(TestContext& testContext);
 

--- a/source/test/TestApp/PlayFabTestAlloc.cpp
+++ b/source/test/TestApp/PlayFabTestAlloc.cpp
@@ -46,21 +46,21 @@ namespace PlayFabUnit
         // Context
         PlayFab::PlayFabAuthenticationContext* testPtrContext = new PlayFab::PlayFabAuthenticationContext();
         testPtrContext->entityId = "this should succeed";
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         testPtrContext->playFabId = "this is conditional";
 #endif
         delete testPtrContext;
 
         std::shared_ptr<PlayFab::PlayFabAuthenticationContext> testMSPContext = std::make_shared<PlayFab::PlayFabAuthenticationContext>();
         testMSPContext->entityId = "this should succeed";
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         testMSPContext->playFabId = "this is conditional";
 #endif
         testMSPContext.reset();
 
         std::shared_ptr<PlayFab::PlayFabAuthenticationContext> testNSpContext = std::shared_ptr<PlayFab::PlayFabAuthenticationContext>(new PlayFab::PlayFabAuthenticationContext());
         testNSpContext->entityId = "this should succeed";
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         testNSpContext->playFabId = "this is conditional";
 #endif
         testNSpContext.reset();

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.cpp
@@ -2,7 +2,7 @@
 
 #include "TestAppPch.h"
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include <playfab/PlayFabClientInstanceApi.h>
 #include <playfab/PlayFabSettings.h>

--- a/source/test/TestApp/PlayFabTestMultiUserInstance.h
+++ b/source/test/TestApp/PlayFabTestMultiUserInstance.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include "TestCase.h"
 

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.cpp
@@ -2,9 +2,9 @@
 
 #include "TestAppPch.h"
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
-#include <playfab/PlayFabClientApi.h>
+#include <playfab/PlayFabClientInstanceApi.h>
 #include <playfab/PlayFabSettings.h>
 #include "TestContext.h"
 #include "PlayFabTestMultiUserStatic.h"
@@ -25,7 +25,7 @@ namespace PlayFabUnit
 
         const auto& user1ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user1ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile1Failure, this, std::placeholders::_1, std::placeholders::_2);
-        PlayFabClientAPI::GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
+        clientApi->GetPlayerProfile(profileRequest, user1ProfileSuccess, user1ProfileFailure, customData);
     }
     void PlayFabTestMultiUserStatic::MultiUserLogin1Failure(const PlayFabError& error, void* /*customData*/)
     {
@@ -49,7 +49,7 @@ namespace PlayFabUnit
 
         const auto& user2ProfileSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user2ProfileFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserProfile2Failure, this, std::placeholders::_1, std::placeholders::_2);
-        PlayFabClientAPI::GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
+        clientApi->GetPlayerProfile(profileRequest, user2ProfileSuccess, user2ProfileFailure, customData);
     }
     void PlayFabTestMultiUserStatic::MultiUserLogin2Failure(const PlayFabError& error, void* /*customData*/)
     {
@@ -75,7 +75,7 @@ namespace PlayFabUnit
 
         const auto& user1LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user1LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin1Failure, this, std::placeholders::_1, std::placeholders::_2);
-        PlayFabClientAPI::LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
+        clientApi->LoginWithCustomID(user1LoginRequest, user1LoginSuccess, user1LoginFailure, &testContext);
 
         LoginWithCustomIDRequest user2LoginRequest;
         user2LoginRequest.CustomId = "test_MultiStatic2";
@@ -84,7 +84,7 @@ namespace PlayFabUnit
 
         const auto& user2LoginSuccess = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Success, this, std::placeholders::_1, std::placeholders::_2);
         const auto& user2LoginFailure = std::bind(&PlayFabTestMultiUserStatic::MultiUserLogin2Failure, this, std::placeholders::_1, std::placeholders::_2);
-        PlayFabClientAPI::LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
+        clientApi->LoginWithCustomID(user2LoginRequest, user2LoginSuccess, user2LoginFailure, &testContext);
     }
 
     void PlayFabTestMultiUserStatic::AddTests()
@@ -94,6 +94,8 @@ namespace PlayFabUnit
 
     void PlayFabTestMultiUserStatic::ClassSetUp()
     {
+        clientApi = std::make_shared<PlayFabClientInstanceAPI>(PlayFabSettings::staticPlayer);
+
         // Ref or create contexts for players
         multiUser1Context = PlayFabSettings::staticPlayer;
         multiUser2Context = std::make_shared<PlayFabAuthenticationContext>();

--- a/source/test/TestApp/PlayFabTestMultiUserStatic.h
+++ b/source/test/TestApp/PlayFabTestMultiUserStatic.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#ifndef DISABLE_PLAYFABCLIENT_API
+#if !defined(DISABLE_PLAYFABCLIENT_API)
 
 #include "TestCase.h"
 
@@ -26,6 +26,7 @@ namespace PlayFabUnit
         /// CLIENT API
         /// Try to log in two users simultaneously using static APIs.
         /// </summary>
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
         std::shared_ptr<PlayFab::PlayFabAuthenticationContext> multiUser1Context;
         std::shared_ptr<PlayFab::PlayFabAuthenticationContext> multiUser2Context;
         std::string multiUser1Error, multiUser2Error;

--- a/source/test/TestApp/TestApp.h
+++ b/source/test/TestApp/TestApp.h
@@ -11,12 +11,13 @@
 
 namespace PlayFab
 {
+    class PlayFabClientInstanceAPI;
     struct PlayFabError;
 
     namespace ClientModels
     {
-        struct ExecuteCloudScriptResult;
         struct LoginResult;
+        struct ExecuteCloudScriptResult;
     }
 }
 
@@ -30,15 +31,18 @@ namespace PlayFabUnit
         static void LogPut(const char* message);
 
     private:
+#if !defined(DISABLE_PLAYFABCLIENT_API)
         // Cloud Report
         std::string cloudResponse = "";
         std::string cloudPlayFabId = "";
         std::mutex cloudResponseMutex;
         std::condition_variable cloudResponseConditionVar;
 
+        std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
         void OnPostReportLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
         void OnPostReportComplete(const PlayFab::ClientModels::ExecuteCloudScriptResult& result, void* /*customData*/);
         void OnPostReportError(const PlayFab::PlayFabError& error, void* /*customData*/);
+#endif
 
         // Utility
         static bool LoadTitleData(TestTitleData& titleData);

--- a/templates/PlayFab_API.h.ejs
+++ b/templates/PlayFab_API.h.ejs
@@ -1,12 +1,15 @@
 #pragma once
 
-<%- getApiDefine(api) %>
+<%- getApiDefine(api) %><%- remStaticDefine %>
 
-#include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFab<%- api.name %>DataModels.h>
+#include <playfab/PlayFabError.h>
 
 namespace PlayFab
 {
+    class CallRequestContainerBase;
+    class CallRequestContainer;
+
     /// <summary>
     /// Main interface for PlayFab Sdk, specifically all <%- api.name %> APIs
     /// </summary>

--- a/templates/PlayFab_Api.cpp.ejs
+++ b/templates/PlayFab_Api.cpp.ejs
@@ -1,6 +1,6 @@
 #include <stdafx.h>
 
-<%- getApiDefine(api) %>
+<%- getApiDefine(api) %><%- remStaticDefine %>
 
 #include <playfab/PlayFab<%- api.name %>Api.h>
 #include <playfab/PlayFabPluginManager.h>

--- a/templates/PlayFab_InstanceAPI.h.ejs
+++ b/templates/PlayFab_InstanceAPI.h.ejs
@@ -2,13 +2,16 @@
 
 <%- getApiDefine(api) %>
 
-#include <playfab/PlayFabCallRequestContainer.h>
-#include <playfab/PlayFabApiSettings.h>
 #include <playfab/PlayFab<%- api.name %>DataModels.h>
-#include <memory>
+#include <playfab/PlayFabError.h>
 
 namespace PlayFab
 {
+    class CallRequestContainerBase;
+    class CallRequestContainer;
+    class PlayFabApiSettings;
+    class PlayFabAuthenticationContext;
+
     /// <summary>
     /// Main interface for PlayFab Sdk, specifically all <%- api.name %> APIs
     /// </summary>

--- a/templates/PlayFab_InstanceApi.cpp.ejs
+++ b/templates/PlayFab_InstanceApi.cpp.ejs
@@ -5,8 +5,6 @@
 #include <playfab/PlayFab<%- api.name %>InstanceApi.h>
 #include <playfab/PlayFabPluginManager.h>
 #include <playfab/PlayFabSettings.h>
-#include <playfab/PlayFabError.h>
-#include <memory>
 
 #if defined(PLAYFAB_PLATFORM_WINDOWS)
 #pragma warning (disable: 4100) // formal parameters are part of a public interface


### PR DESCRIPTION
DISABLE_PLAYFAB_STATIC_API can be used to disable all static API interfaces/files to reduce the size of the ExecuteCloudScript
Updating all the features and tests to use instances (with staticPlayer, which is equivalent) internally, rather than static APIs
A handful of header improvements (not nearly complete, but a few steps in the right direction)
Adding some missing AuthenticationContext signatures (IsClientLoggedIn and IsEntityLoggedIn)
Utilizing the context a little better in some tests, rather than copying to internal variables

View the SDK changes that mirror these template changes here:
https://github.com/PlayFab/XPlatCppSdk/pull/38/files