### PR TITLE
Adding a check for enableing QoS

### DIFF
--- a/source/code/include/playfab/QoS/PingResult.h
+++ b/source/code/include/playfab/QoS/PingResult.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined (ENABLE_QOS)
 #include <cstdint>
 
 namespace PlayFab
@@ -26,3 +27,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/include/playfab/QoS/PlayFabQoSApi.h
+++ b/source/code/include/playfab/QoS/PlayFabQoSApi.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined (ENABLE_QOS)
 
 #include <playfab/QoS/QoS.h>
 #include <playfab/QoS/QoSResult.h>
@@ -60,3 +61,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/include/playfab/QoS/QoS.h
+++ b/source/code/include/playfab/QoS/QoS.h
@@ -3,6 +3,8 @@
 /// </summary>
 
 #pragma once
+
+#if defined (ENABLE_QOS)
 #include <iostream>
 
 // define body for logging or debug output
@@ -35,3 +37,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/include/playfab/QoS/QoSResult.h
+++ b/source/code/include/playfab/QoS/QoSResult.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined (ENABLE_QOS)
 #include <vector>
 
 #include <playfab/QoS/RegionResult.h>
@@ -28,3 +29,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/include/playfab/QoS/RegionResult.h
+++ b/source/code/include/playfab/QoS/RegionResult.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined (ENABLE_QOS)
 #include <string>
 #include <playfab/PlayFabMultiplayerDataModels.h>
 
@@ -27,3 +28,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/include/playfab/QoS/XPlatSocket.h
+++ b/source/code/include/playfab/QoS/XPlatSocket.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#if defined (ENABLE_QOS)
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
 #include <winsock2.h>
 #include <Windows.h>
@@ -81,3 +82,4 @@ namespace PlayFab
         };
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.h>
 
+#if defined (ENABLE_QOS)
 #include <cstdint>
 
 #include <playfab/QoS/QoS.h>
@@ -392,3 +393,4 @@ namespace PlayFab
         }
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/source/playfab/QoS/QoSSocket.cpp
+++ b/source/code/source/playfab/QoS/QoSSocket.cpp
@@ -1,5 +1,7 @@
 #include <stdafx.h>
 
+#if defined (ENABLE_QOS)
+
 #include <chrono>
 #include <thread>
 #include <iostream>
@@ -88,3 +90,4 @@ namespace PlayFab
         }
     }
 }
+#endif defined (ENABLE_QOS)

--- a/source/code/source/playfab/QoS/RegionResult.cpp
+++ b/source/code/source/playfab/QoS/RegionResult.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.h>
 
+#if defined (ENABLE_QOS)
 #include <playfab/QoS/RegionResult.h>
 
 namespace PlayFab
@@ -12,3 +13,4 @@ namespace PlayFab
         }
     }
 }
+#endif // defined (ENABLE_QOS)

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -1,5 +1,6 @@
 #include <stdafx.h>
 
+#if defined (ENABLE_QOS)
 #include <playfab/QoS/XPlatSocket.h>
 #include <playfab/QoS/QoS.h>
 
@@ -218,3 +219,4 @@ namespace PlayFab
 
     }
 }
+#endif // defined (ENABLE_QOS)


### PR DESCRIPTION
QoS is an incomplete feature. We don't have cross platform tests and customers of other platforms are wondering why Windows has warning supressions but the other platforms don't have that same supression.