### PR TITLE
QoS can only properly be enabled for Windows and Xbox

### DIFF
--- a/source/code/include/playfab/QoS/PingResult.h
+++ b/source/code/include/playfab/QoS/PingResult.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <cstdint>
 
 namespace PlayFab
@@ -27,4 +27,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/PlayFabQoSApi.h
+++ b/source/code/include/playfab/QoS/PlayFabQoSApi.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 
 #include <playfab/QoS/QoS.h>
 #include <playfab/QoS/QoSResult.h>
@@ -61,4 +61,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/QoS.h
+++ b/source/code/include/playfab/QoS/QoS.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <iostream>
 
 // define body for logging or debug output
@@ -37,4 +37,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/QoSResult.h
+++ b/source/code/include/playfab/QoS/QoSResult.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <vector>
 
 #include <playfab/QoS/RegionResult.h>
@@ -29,4 +29,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/QoSSocket.h
+++ b/source/code/include/playfab/QoS/QoSSocket.h
@@ -1,11 +1,8 @@
 #pragma once
 
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <playfab/QoS/XPlatSocket.h>
 #include <playfab/QoS/PingResult.h>
-
-#if defined(PLAYFAB_PLATFORM_WINDOWS)
-#pragma warning (disable: 4309)     // Suppress static cast conversion of const value (line 54)
-#endif // defined(PLAYFAB_PLATFORM_WINDOWS)
 
 namespace PlayFab
 {
@@ -13,7 +10,7 @@ namespace PlayFab
     {
         constexpr int BUFLEN = 512; // Length of the message send and received
 
-        constexpr int MSGHEADER = 255; // Header of the message send over UDP
+        constexpr unsigned int MSGHEADER = 255; // Header of the message send over UDP
                                        // The message must start with 2 bytes of all bits set to 1
 
         constexpr char BUFFER_VALUE = '1'; // Clear the buffer with this value before receiving the reply.
@@ -56,7 +53,4 @@ namespace PlayFab
         };
     }
 }
-
-#if defined(PLAYFAB_PLATFORM_WINDOWS)
-#pragma warning (default: 4309)     // Suppress static cast conversion of const value (line 54)
-#endif // defined(PLAYFAB_PLATFORM_WINDOWS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/RegionResult.h
+++ b/source/code/include/playfab/QoS/RegionResult.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <string>
 #include <playfab/PlayFabMultiplayerDataModels.h>
 
@@ -28,4 +28,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/include/playfab/QoS/XPlatSocket.h
+++ b/source/code/include/playfab/QoS/XPlatSocket.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
 #include <winsock2.h>
 #include <Windows.h>
@@ -82,4 +82,4 @@ namespace PlayFab
         };
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -1,6 +1,6 @@
 #include <stdafx.h>
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <cstdint>
 
 #include <playfab/QoS/QoS.h>
@@ -393,4 +393,4 @@ namespace PlayFab
         }
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/source/playfab/QoS/QoSSocket.cpp
+++ b/source/code/source/playfab/QoS/QoSSocket.cpp
@@ -1,6 +1,6 @@
 #include <stdafx.h>
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 
 #include <chrono>
 #include <thread>
@@ -90,4 +90,4 @@ namespace PlayFab
         }
     }
 }
-#endif defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/source/playfab/QoS/RegionResult.cpp
+++ b/source/code/source/playfab/QoS/RegionResult.cpp
@@ -1,6 +1,6 @@
 #include <stdafx.h>
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <playfab/QoS/RegionResult.h>
 
 namespace PlayFab
@@ -13,4 +13,4 @@ namespace PlayFab
         }
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -1,6 +1,6 @@
 #include <stdafx.h>
 
-#if defined (ENABLE_QOS)
+#if defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)
 #include <playfab/QoS/XPlatSocket.h>
 #include <playfab/QoS/QoS.h>
 
@@ -219,4 +219,4 @@ namespace PlayFab
 
     }
 }
-#endif // defined (ENABLE_QOS)
+#endif // defined (PLAYFAB_PLATFORM_WINDOWS) || defined (PLAYFAB_PLATFORM_XBOX)

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -11,7 +11,9 @@
 #include <playfab/PlayFabEventsDataModels.h>
 #include <playfab/PlayFabEventsInstanceApi.h>
 #include <playfab/PlayFabSettings.h>
+#if QOS_ENABLED
 #include <playfab/QoS/PlayFabQoSApi.h>
+#endif // QOS_ENABLED
 #include "PlayFabEventTest.h"
 #include "TestContext.h"
 #include "TestDataTypes.h"
@@ -22,6 +24,7 @@ using namespace EventsModels;
 
 namespace PlayFabUnit
 {
+#if QOS_ENABLED
 #if (!UNITY_IOS && !UNITY_ANDROID) && (!defined(PLAYFAB_PLATFORM_IOS) && !defined(PLAYFAB_PLATFORM_ANDROID) && !defined(PLAYFAB_PLATFORM_SWITCH))
     /// QoS API
     void PlayFabEventTest::QosResultApi(TestContext& testContext)
@@ -39,8 +42,8 @@ namespace PlayFabUnit
             testContext.Fail("Error Code:" + std::to_string(result.errorCode));
         }
     }
-#endif
-
+#endif // Platform test limits
+#endif // QOS_ENABLED
     void PlayFabEventTest::OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData)
     {
         TestContext* testContext = static_cast<TestContext*>(customData);

--- a/source/test/TestApp/PlayFabEventTest.cpp
+++ b/source/test/TestApp/PlayFabEventTest.cpp
@@ -11,9 +11,6 @@
 #include <playfab/PlayFabEventsDataModels.h>
 #include <playfab/PlayFabEventsInstanceApi.h>
 #include <playfab/PlayFabSettings.h>
-#if QOS_ENABLED
-#include <playfab/QoS/PlayFabQoSApi.h>
-#endif // QOS_ENABLED
 #include "PlayFabEventTest.h"
 #include "TestContext.h"
 #include "TestDataTypes.h"
@@ -24,26 +21,6 @@ using namespace EventsModels;
 
 namespace PlayFabUnit
 {
-#if QOS_ENABLED
-#if (!UNITY_IOS && !UNITY_ANDROID) && (!defined(PLAYFAB_PLATFORM_IOS) && !defined(PLAYFAB_PLATFORM_ANDROID) && !defined(PLAYFAB_PLATFORM_SWITCH))
-    /// QoS API
-    void PlayFabEventTest::QosResultApi(TestContext& testContext)
-    {
-        QoS::PlayFabQoSApi api;
-
-        QoS::QoSResult result = api.GetQoSResult(5, 200);
-
-        if (result.errorCode == 0)
-        {
-            testContext.Pass();
-        }
-        else
-        {
-            testContext.Fail("Error Code:" + std::to_string(result.errorCode));
-        }
-    }
-#endif // Platform test limits
-#endif // QOS_ENABLED
     void PlayFabEventTest::OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData)
     {
         TestContext* testContext = static_cast<TestContext*>(customData);
@@ -298,12 +275,6 @@ namespace PlayFabUnit
     void PlayFabEventTest::AddTests()
     {
         AddTest("BasicLogin", &PlayFabEventTest::BasicLogin);
-
-        // It is not appropriate for this test to block infinitely until the QoS result is returned
-        // Not the least of which is because it frequently blocks forever
-        // This needs to switch to the async mechanism, and allow the test to time out if QoS never completes
-        // AddTest("QosResultApi", &PlayFabEventTest::QosResultApi);
-
         AddTest("EventsApi", &PlayFabEventTest::EventsApi);
         AddTest("HeavyweightEvents", &PlayFabEventTest::HeavyweightEvents);
         AddTest("LightweightEvents", &PlayFabEventTest::LightweightEvents);

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -37,11 +37,6 @@ namespace PlayFabUnit
         std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
         std::shared_ptr<PlayFab::PlayFabEventsInstanceAPI> eventsApi;
 
-#if QOS_ENABLED
-        /// QoS API
-        void QosResultApi(TestContext& testContext);
-#endif // QOS_ENABLED
-
         // Initial Login
         void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);
         void BasicLogin(TestContext& testContext);

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -37,8 +37,10 @@ namespace PlayFabUnit
         std::shared_ptr<PlayFab::PlayFabClientInstanceAPI> clientApi;
         std::shared_ptr<PlayFab::PlayFabEventsInstanceAPI> eventsApi;
 
+#if QOS_ENABLED
         /// QoS API
         void QosResultApi(TestContext& testContext);
+#endif // QOS_ENABLED
 
         // Initial Login
         void OnErrorSharedCallback(const PlayFab::PlayFabError& error, void* customData);

--- a/source/test/TestApp/PlayFabQoSTest.cpp
+++ b/source/test/TestApp/PlayFabQoSTest.cpp
@@ -1,0 +1,79 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#include "TestAppPch.h"
+
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+
+#include <thread>
+#include <chrono>
+#include <playfab/PlayFabClientDataModels.h>
+#include <playfab/PlayFabClientInstanceApi.h>
+#include <playfab/PlayFabEventsDataModels.h>
+#include <playfab/PlayFabEventsInstanceApi.h>
+#include <playfab/PlayFabSettings.h>
+#include <playfab/QoS/PlayFabQoSApi.h>
+#include "PlayFabQoSTest.h"
+#include "TestContext.h"
+#include "TestDataTypes.h"
+
+using namespace PlayFab;
+using namespace ClientModels;
+using namespace EventsModels;
+
+namespace PlayFabUnit
+{
+#if (!UNITY_IOS && !UNITY_ANDROID) && (!defined(PLAYFAB_PLATFORM_IOS) && !defined(PLAYFAB_PLATFORM_ANDROID) && !defined(PLAYFAB_PLATFORM_SWITCH))
+    /// QoS API
+    void PlayFabQoSTest::QosResultApi(TestContext& testContext)
+    {
+        QoS::PlayFabQoSApi api;
+
+        QoS::QoSResult result = api.GetQoSResult(5, 200);
+
+        if (result.errorCode == 0)
+        {
+            testContext.Pass();
+        }
+        else
+        {
+            testContext.Fail("Error Code:" + std::to_string(result.errorCode));
+        }
+    }
+#endif
+
+    void PlayFabEventTest::AddTests()
+    {
+        // It is not appropriate for this test to block infinitely until the QoS result is returned
+        // Not the least of which is because it frequently blocks forever
+        // This needs to switch to the async mechanism, and allow the test to time out if QoS never completes
+        // AddTest("QosResultApi", &PlayFabEventTest::QosResultApi);
+    }
+
+    void PlayFabEventTest::ClassSetUp()
+    {
+        // Make sure PlayFab state is clean.
+        PlayFabSettings::ForgetAllCredentials();
+    }
+
+    void PlayFabEventTest::SetUp(TestContext& /*testContext*/)
+    {
+        PlayFabSettings::staticSettings->titleId = testTitleData.titleId;
+    }
+
+    void PlayFabEventTest::Tick(TestContext& /*testContext*/)
+    {
+        // No work needed, async tests will end themselves
+    }
+
+    void PlayFabEventTest::TearDown(TestContext& /*testContext*/)
+    {
+        // nothing to tear down
+    }
+
+    void PlayFabEventTest::ClassTearDown()
+    {
+        // Clean up any PlayFab state for next TestCase.
+        PlayFabSettings::ForgetAllCredentials();
+    }
+}
+#endif //defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)

--- a/source/test/TestApp/PlayFabQoSTest.h
+++ b/source/test/TestApp/PlayFabQoSTest.h
@@ -1,0 +1,39 @@
+// Copyright (C) Microsoft Corporation. All rights reserved.
+
+#pragma once
+
+#if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
+
+#include <string>
+#include "TestCase.h"
+
+namespace PlayFabUnit
+{
+    struct TestContext;
+
+    // A wrapper around TestEvents, so we can track it back to the test that launched the event
+    class TestEvent : public PlayFab::PlayFabEvent
+    {
+    public:
+        TestContext* testContext;
+    };
+
+    class PlayFabQoSTest : public PlayFabApiTestCase
+    {
+    private:
+
+        void QosResultApi(TestContext& testContext);
+
+    protected:
+        void AddTests() override;
+
+    public:
+        void ClassSetUp() override;
+        void SetUp(TestContext& /*testContext*/) override;
+        void Tick(TestContext& testContext) override;
+        void TearDown(TestContext& /*testContext*/) override;
+        void ClassTearDown() override;
+    };
+}
+
+#endif //defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)


### PR DESCRIPTION
Explicilty removing enabling flags for QoS in favor of platform specific changes.

Also removes pragma warning disables and fixes the warning issue directly.