### PR TITLE
Fix Xbox compile error

### DIFF
--- a/source/build/Xbox/TestXboxApp/MainXBO.cpp
+++ b/source/build/Xbox/TestXboxApp/MainXBO.cpp
@@ -62,7 +62,7 @@ ref class ViewProvider sealed : public IFrameworkView
 
         void OnSuspending(Platform::Object^ sender, SuspendingEventArgs^ args)
         {
-            SuspendingDeferral deferral = args->SuspendingOperation->GetDeferral();
+            SuspendingDeferral^ deferral = args->SuspendingOperation->GetDeferral();
 
             create_task([this, deferral]()
             {


### PR DESCRIPTION
GetDeferral returns a Managed Pointer, without this ^ we get an error when compiling Xbox.