### PR TITLE
Update PlayFabBaseModel.h

### DIFF
--- a/source/code/include/playfab/PlayFabBaseModel.h
+++ b/source/code/include/playfab/PlayFabBaseModel.h
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <functional>
 #include <list>
+#include <memory>
 
 namespace PlayFab
 {


### PR DESCRIPTION
The proposed includes are required for ps4. Just forcing the stdafx include is fine for building a static library, but 1.) there's no .a output library. 2.) no test project is able to link to that missing .a output library after forcing the stdafx include 3.) no test can by default see the stdafx file, it needs a particular path making it seem like we may want to re-consider project paths (if we share the same Debug folder for multiple projects there's a warning describing issues with Clean and Rebuild).