### PR TITLE
Update XPlatSocket.cpp

### DIFF
--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -20,6 +20,7 @@ namespace PlayFab
         XPlatSocket::XPlatSocket()
         {
             initialized = false;
+            memset(&timeOutVal, 0, sizeof(timeOutVal));
         }
 
         XPlatSocket::~XPlatSocket()
@@ -80,9 +81,11 @@ namespace PlayFab
                 return -1;
             }
 
-            // Input timeout is in milliseconds
+            // Input timeout is in milliseconds, tv_sec is in seconds
+            timeOutVal.tv_sec = timeoutMs / 1000;
+
             // tv_usec takes microseconds, hence convert the input milliseconds to microseconds
-            timeOutVal.tv_usec = timeoutMs * 1000;
+            timeOutVal.tv_usec = (timeoutMs - timeOutVal.tv_sec * 1000) * 1000;
 #if defined(PLAYFAB_PLATFORM_WINDOWS) || defined(PLAYFAB_PLATFORM_XBOX)
             return setsockopt(s, SOL_SOCKET, SO_RCVTIMEO | SO_SNDTIMEO, reinterpret_cast<const char*>(&timeoutMs), sizeof(timeoutMs));
 #else

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -20,7 +20,7 @@ namespace PlayFab
         XPlatSocket::XPlatSocket()
         {
             initialized = false;
-            memset(&timeOutVal, 0, sizeof(timeOutVal));
+            timeOutVal = (struct timeval){ 0 };
         }
 
         XPlatSocket::~XPlatSocket()


### PR DESCRIPTION
initializing timeOutVal in QoS. As a struct, certain compilers will do fine with this, but GNU has explicit expectations on this time struct being initialized before use.

We supposedly also didn't take into account the micro second nature of _usec according to one customer reported issue (just converting to milliseconds is wrong since usec is alredy noted as micro seconds).
