### PR TITLE
Update PlayFabQoSApi.cpp

### DIFF
--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -22,7 +22,7 @@ namespace PlayFab
 {
     namespace QoS
     {
-        static const size_t MaxWaitForFuturesLoopCounts = 1000;
+        static const size_t MaxWaitForFuturesLoopCounts = 300;
         PlayFabQoSApi::PlayFabQoSApi()
         {
             eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -22,7 +22,7 @@ namespace PlayFab
 {
     namespace QoS
     {
-        static const int MaxWaitForFuturesLoopCounts = 1000;
+        static const size_t MaxWaitForFuturesLoopCounts = 1000;
         PlayFabQoSApi::PlayFabQoSApi()
         {
             eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -287,7 +287,7 @@ namespace PlayFab
                 // Iterate over all the threads and servers that need to be pinged
                 for (size_t i = 0; i < numThreads && pingItr < numPings; ++i)
                 {
-                    if (asyncPingResults[i].valid()) // the very first ping result might be a fake future
+                    while (asyncPingResults[i].valid()) // the very first ping result might be a fake future
                     {
                         future_status status = asyncPingResults[i].wait_for(threadWaitTimespan);
                         if (status == future_status::ready)

--- a/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
+++ b/source/code/source/playfab/QoS/PlayFabQoSApi.cpp
@@ -22,6 +22,7 @@ namespace PlayFab
 {
     namespace QoS
     {
+        static const int MaxWaitForFuturesLoopCounts = 1000;
         PlayFabQoSApi::PlayFabQoSApi()
         {
             eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);
@@ -287,7 +288,8 @@ namespace PlayFab
                 // Iterate over all the threads and servers that need to be pinged
                 for (size_t i = 0; i < numThreads && pingItr < numPings; ++i)
                 {
-                    while (asyncPingResults[i].valid()) // the very first ping result might be a fake future
+                    // NOTE: the very first ping result might be a fake future
+                    for (size_t futuresCount = 0; futuresCount < MaxWaitForFuturesLoopCounts || asyncPingResults[i].valid(); ++futuresCount)
                     {
                         future_status status = asyncPingResults[i].wait_for(threadWaitTimespan);
                         if (status == future_status::ready)

--- a/source/code/source/playfab/QoS/XPlatSocket.cpp
+++ b/source/code/source/playfab/QoS/XPlatSocket.cpp
@@ -20,7 +20,7 @@ namespace PlayFab
         XPlatSocket::XPlatSocket()
         {
             initialized = false;
-            timeOutVal = (struct timeval){ 0 };
+            timeOutVal = { 0 };
         }
 
         XPlatSocket::~XPlatSocket()


### PR DESCRIPTION
Current implementation can potentially fail in the event of a time out.

A user reported:

"If the future_status status = asyncPingResults[i].wait_for(pingWaitTime); just timeout, the result is never pulled... when the PlayFabQoSApi::GetResult method returns, the vector<future<PingResult>> asyncPingResults variable destruction cause the code to wait for all future tasks not completed yet."

So replacing the initial if with a while in this particular case should be fine.  There is a question though as to whether or not this starts blocking a thread if we are looping in this manner.