### PR TITLE
adding a lock to pf event pipeline

### DIFF
--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -73,7 +73,7 @@ namespace PlayFab
         void SetExceptionCallback(ExceptionCallback callback);
 
     protected:
-        virtual void SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, size_t& batchCounter);
+        virtual void SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, uintptr_t& batchCounter);
 
     private:
         void WorkerThread();

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -87,6 +87,7 @@ namespace PlayFab
         // We are using that feature (custom pointer relay) because we need to know which batch it was when we receive a callback from the Events API.
         // To keep track of all batches currently in flight (i.e. those for which we called Events API) we need to have a container with controllable size
         // that would allow to quickly map a pointer (like void* customData) to a batch (like a std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>).
+        std::mutex inFlightMutex;
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -89,7 +89,6 @@ namespace PlayFab
         // that would allow to quickly map a pointer (like void* customData) to a batch (like a std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>).
         std::mutex inFlightMutex;
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
-        //std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -73,7 +73,7 @@ namespace PlayFab
         void SetExceptionCallback(ExceptionCallback callback);
 
     protected:
-        virtual void SendBatch(size_t& batchCounter);
+        virtual void SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, size_t& batchCounter);
 
     private:
         void WorkerThread();
@@ -89,7 +89,7 @@ namespace PlayFab
         // that would allow to quickly map a pointer (like void* customData) to a batch (like a std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>).
         std::mutex inFlightMutex;
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
-        std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
+        //std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -100,6 +100,8 @@ namespace PlayFab
         std::atomic<bool> isWorkerThreadRunning;
         std::mutex userExceptionCallbackMutex;
         ExceptionCallback userExceptionCallback;
+
+        bool TryGetBatchOutOfFlight(void* customData, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>* batchReturn);
     };
 }
 

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -318,7 +318,7 @@ namespace PlayFab
                     playFabEmitEventResponse->playFabError = playFabError;
                     playFabEmitEventResponse->writeEventsResponse = std::shared_ptr<EventsModels::WriteEventsResponse>(new EventsModels::WriteEventsResponse(result));
                     playFabEmitEventResponse->batch = requestBatchPtr;
-                    playFabEmitEventResponse->batchNumber = reinterpret_cast<size_t>(customData);
+                    playFabEmitEventResponse->batchNumber = static_cast<size_t>(reinterpret_cast<uintptr_t>(customData));
 
                     // call an emit event callback
                     CallbackRequest(playFabEmitRequest, std::move(playFabEmitEventResponse));

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -45,7 +45,6 @@ namespace PlayFab
         eventsApi = std::make_shared<PlayFabEventsInstanceAPI>(PlayFabSettings::staticPlayer);
 
         this->settings = settings;
-        //this->batch.reserve(this->settings->maximalNumberOfItemsInBatch);
         this->batchesInFlight.reserve(this->settings->maximalNumberOfBatchesInFlight);
         this->Start();
     }
@@ -174,7 +173,7 @@ namespace PlayFab
 
                 { // LOCK batchesInFlight mutex
                     std::unique_lock<std::mutex> lock(inFlightMutex);
-                    sizeOfBatchesInFlight = batchesInFlight.size();
+                    sizeOfBatchesInFlight = this->batchesInFlight.size();
                 } // UNLOCK batchesInFlight
 
                 // Process events in the loop

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -304,8 +304,7 @@ namespace PlayFab
             std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batchWritten;
             if(TryGetBatchOutOfFlight(customData, &batchWritten))
             {
-                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(std::move(batchWritten)));
-
+                auto requestBatchPtr = std::make_shared<std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(std::move(batchWritten));
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
                 {
@@ -343,8 +342,7 @@ namespace PlayFab
             std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batchWritten;
             if(TryGetBatchOutOfFlight(customData, &batchWritten))
             {
-                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(std::move(batchWritten)));
-
+                auto requestBatchPtr = std::make_shared<std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(std::move(batchWritten));
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
                 {

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -304,7 +304,7 @@ namespace PlayFab
             std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batchWritten;
             if(TryGetBatchOutOfFlight(customData, &batchWritten))
             {
-                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(batchWritten));
+                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(std::move(batchWritten)));
 
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
@@ -326,7 +326,7 @@ namespace PlayFab
             }
             else
             {
-                LOG_PIPELINE("After a balid PlayFabEventPipeline write call, the requeted return Batch did not appear in our known flighted batches, there is no trustworthy data we can return to the user");
+                LOG_PIPELINE("After a valid PlayFabEventPipeline write call, the requested return Batch did not appear in our known flighted batches, there is no trustworthy data we can return to the user");
             }
             
         }
@@ -343,7 +343,7 @@ namespace PlayFab
             std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batchWritten;
             if(TryGetBatchOutOfFlight(customData, &batchWritten))
             {
-                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(batchWritten));
+                auto requestBatchPtr = std::shared_ptr<const std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>>(new std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>(std::move(batchWritten)));
 
                 // call individual emit event callbacks
                 for (const auto& eventEmitRequest : *requestBatchPtr)
@@ -393,7 +393,7 @@ namespace PlayFab
         if (iter == this->batchesInFlight.end())
         {
             // not finding the batch in the queue is a bug
-            LOG_PIPELINE("Untracked batch was returned to EventsAPI.WriteEvents callback"); // normally this never happens
+            LOG_PIPELINE("Untracked batch was returned to EventsAPI.WriteEvents callback");
             return false;
         }
 

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -351,7 +351,7 @@ namespace PlayFab
                     playFabEmitEventResponse->emitEventResult = EmitEventResult::Success;
                     playFabEmitEventResponse->playFabError = std::shared_ptr<PlayFabError>(new PlayFabError(error));
                     playFabEmitEventResponse->batch = requestBatchPtr;
-                    playFabEmitEventResponse->batchNumber = reinterpret_cast<size_t>(customData);
+                    playFabEmitEventResponse->batchNumber = static_cast<size_t>(reinterpret_cast<uintptr_t>(customData));
 
                     // call an emit event callback
                     CallbackRequest(playFabEmitRequest, std::move(playFabEmitEventResponse));

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -184,30 +184,30 @@ namespace PlayFab
 
                 switch (this->buffer.TryTake(request))
                 {
-                    case Result::Success:
+                case Result::Success:
+                {
+                    // add an event to batch
+                    this->batch.push_back(std::move(request));
+
+                    // if batch is full
+                    if (this->batch.size() >= this->settings->maximalNumberOfItemsInBatch)
                     {
-                        // add an event to batch
-                        this->batch.push_back(std::move(request));
-
-                        // if batch is full
-                        if (this->batch.size() >= this->settings->maximalNumberOfItemsInBatch)
-                        {
-                            this->SendBatch(batchCounter);
-                        }
-                        else if (this->batch.size() == 1)
-                        {
-                            // if it is the first event in an incomplete batch then set the batch creation moment
-                            momentBatchStarted = clock::now();
-                        }
-
-                        continue; // immediately check if there is next event in buffer
+                        this->SendBatch(batchCounter);
                     }
-                    break;
+                    else if (this->batch.size() == 1)
+                    {
+                        // if it is the first event in an incomplete batch then set the batch creation moment
+                        momentBatchStarted = clock::now();
+                    }
 
-                    case Result::Disabled:
-                    case Result::Empty:
-                    default:
-                        break;
+                    continue; // immediately check if there is next event in buffer
+                }
+                break;
+
+                case Result::Disabled:
+                case Result::Empty:
+                default:
+                    break;
                 }
 
                 // if batch was started

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -159,7 +159,7 @@ namespace PlayFab
         using clock = std::chrono::steady_clock;
         using Result = PlayFabEventBuffer::EventConsumingResult;
         std::shared_ptr<const IPlayFabEmitEventRequest> request;
-        size_t batchCounter = 1; // used to track uniqueness of batches in the map
+        uintptr_t batchCounter = 1; // used to track uniqueness of batches in the map
         std::chrono::steady_clock::time_point momentBatchStarted; // used to track when a currently assembled batch got its first event
         
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
@@ -251,7 +251,7 @@ namespace PlayFab
         }
     }
 
-    void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, size_t& batchCounter)
+    void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, uintptr_t& batchCounter)
     {
         // create a WriteEvents API request to send the batch
         EventsModels::WriteEventsRequest batchReq;


### PR DESCRIPTION
We may read/write to batchesInFlight on multiple threads (either worker thread, callback, or other possible thread if you inherit from our pipeline). Therefore, we should add some locks to this particular structure. 

This bug was created earlier this week: https://dev.azure.com/playfab/PlayFab/_workitems/edit/42545 