### PR TITLE
Update PlayFabIOSHttpPlugin.mm

### DIFF
--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -272,10 +272,6 @@ namespace PlayFab
                                                                        {
                                                                            requestContainer.responseString = [body UTF8String];
                                                                        }
-                                                                       else
-                                                                       {
-                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin failed to parse body as it is nil";
-                                                                       }
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex
                                                                            lock->lock();

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -272,6 +272,10 @@ namespace PlayFab
                                                                        {
                                                                         requestContainer.responseString = [body UTF8String];
                                                                        }
+                                                                       else
+                                                                       {
+                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin Failed to parse body";
+                                                                       }
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex
                                                                            lock->lock();

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -274,7 +274,7 @@ namespace PlayFab
                                                                        }
                                                                        else
                                                                        {
-                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin Failed to parse body";
+                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin Failed to parse body as it is nil";
                                                                        }
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -268,7 +268,10 @@ namespace PlayFab
                                                                        NSString* body = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
 
                                                                        CallRequestContainer& requestContainer = request->RequestContainer();
-                                                                       requestContainer.responseString = [body UTF8String];
+                                                                       if(body != nil)
+                                                                       {
+                                                                        requestContainer.responseString = [body UTF8String];
+                                                                       }
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex
                                                                            lock->lock();

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -270,11 +270,11 @@ namespace PlayFab
                                                                        CallRequestContainer& requestContainer = request->RequestContainer();
                                                                        if(body != nil)
                                                                        {
-                                                                        requestContainer.responseString = [body UTF8String];
+                                                                           requestContainer.responseString = [body UTF8String];
                                                                        }
                                                                        else
                                                                        {
-                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin Failed to parse body as it is nil";
+                                                                           requestContainer.responseString = "PlayFabIOSHttpPlugin failed to parse body as it is nil";
                                                                        }
                                                                        ProcessResponse(*request, static_cast<const int>(httpResponse.statusCode));
                                                                        { // LOCK httpRequestMutex


### PR DESCRIPTION
Quick fix to see if the object named body is nil before we attempt to reference it in a response back to a user to fix this customer reported issue

https://github.com/PlayFab/XPlatCoreTemplate/issues/79

If PlayFab fail's here, we will be sending back an error to the user. So the responseString should reflect the error to be more easily debugged by the customer (if the body is nil, there would have been no information to give back to the customer anyway, so adding in error info to this response would be more helpful than no info.