### PR TITLE
Update PlayFabWinHttpPlugin.cpp

### DIFF
--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -36,8 +36,8 @@ namespace PlayFab
         void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);
         void SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode = 0) const;
 
-        bool TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders, DWORD dwHeadersLength, DWORD dwModifiers);
-        void CloseOutConnections(std::unique_ptr<CallRequestContainer> requestContainer, HINTERNET hRequest, HINTERNET hConnect, HINTERNET hSession);
+        bool TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders);
+        void CompleteRequest(std::unique_ptr<CallRequestContainer> requestContainer, HINTERNET hRequest, HINTERNET hConnect, HINTERNET hSession);
 
         std::thread workerThread;
         std::mutex httpRequestMutex;

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -42,7 +42,7 @@ namespace PlayFab
         std::thread workerThread;
         std::mutex httpRequestMutex;
         std::atomic<bool> threadRunning;
-        std::atomic<bool> headerNoErrors;
+        std::atomic<bool> setPredefinedHeadersFailed;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -42,7 +42,7 @@ namespace PlayFab
         std::thread workerThread;
         std::mutex httpRequestMutex;
         std::atomic<bool> threadRunning;
-        std::atomic<BOOL> setPredefinedHeadersFailed;
+        std::atomic<HRESULT> setPredefinedHeadersResult;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -36,13 +36,13 @@ namespace PlayFab
         void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);
         void SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode = 0) const;
 
-        bool TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders);
+        BOOL TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders);
         void CompleteRequest(std::unique_ptr<CallRequestContainer> requestContainer, HINTERNET hRequest, HINTERNET hConnect, HINTERNET hSession);
 
         std::thread workerThread;
         std::mutex httpRequestMutex;
         std::atomic<bool> threadRunning;
-        std::atomic<bool> setPredefinedHeadersFailed;
+        std::atomic<BOOL> setPredefinedHeadersFailed;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -36,9 +36,13 @@ namespace PlayFab
         void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);
         void SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode = 0) const;
 
+        bool TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders, DWORD dwHeadersLength, DWORD dwModifiers);
+        void CloseOutConnections(std::unique_ptr<CallRequestContainer> requestContainer, HINTERNET hRequest, HINTERNET hConnect, HINTERNET hSession);
+
         std::thread workerThread;
         std::mutex httpRequestMutex;
         std::atomic<bool> threadRunning;
+        std::atomic<bool> headerNoErrors;
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;

--- a/source/code/include/playfab/PlayFabWinHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabWinHttpPlugin.h
@@ -36,7 +36,7 @@ namespace PlayFab
         void HandleResults(std::unique_ptr<CallRequestContainer> requestContainer);
         void SetErrorInfo(CallRequestContainer& requestContainer, const std::string& errorMessage, const int httpCode = 0) const;
 
-        BOOL TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders);
+        HRESULT TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders);
         void CompleteRequest(std::unique_ptr<CallRequestContainer> requestContainer, HINTERNET hRequest, HINTERNET hConnect, HINTERNET hSession);
 
         std::thread workerThread;

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -16,7 +16,7 @@ namespace PlayFab
     {
         activeRequestCount = 0;
         threadRunning = true;
-        setPredefinedHeadersFailed = false;
+        setPredefinedHeadersFailed = FALSE;
         workerThread = std::thread(&PlayFabWinHttpPlugin::WorkerThread, this);
     };
 
@@ -376,9 +376,9 @@ namespace PlayFab
             TryAddHeader(hRequest, L"X-ReportErrorAsSuccess: true");
     }
 
-    bool PlayFabWinHttpPlugin::TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders)
+    BOOL PlayFabWinHttpPlugin::TryAddHeader(HINTERNET hRequest, LPCWSTR lpszHeaders)
     {
-        return static_cast<bool>(WinHttpAddRequestHeaders(hRequest, lpszHeaders, -1, 0));
+        return WinHttpAddRequestHeaders(hRequest, lpszHeaders, -1, 0);
     }
 
     bool PlayFabWinHttpPlugin::GetBinaryPayload(CallRequestContainer& reqContainer, LPVOID& payload, DWORD& payloadSize) const

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -16,7 +16,7 @@ namespace PlayFab
     {
         activeRequestCount = 0;
         threadRunning = true;
-        headerNoErrors = true;
+        setPredefinedHeadersFailed = false;
         workerThread = std::thread(&PlayFabWinHttpPlugin::WorkerThread, this);
     };
 
@@ -193,11 +193,11 @@ namespace PlayFab
                     {
                         // Add HTTP headers
                         SetPredefinedHeaders(reqContainer, hRequest);
-                        if(!headerNoErrors)
+                        if(!setPredefinedHeadersFailed)
                         {
                             SetErrorInfo(reqContainer, "Error in attempting to add Default Headers with HRESULT: " + std::to_string(GetLastError()));
                             CompleteRequest(std::move(requestContainer), hRequest, hConnect, hSession);
-                            headerNoErrors = true;
+                            setPredefinedHeadersFailed = true;
                             return;
                         }
 
@@ -370,7 +370,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::SetPredefinedHeaders(const CallRequestContainer& requestContainer, HINTERNET hRequest)
     {
         UNREFERENCED_PARAMETER(requestContainer);
-        headerNoErrors = TryAddHeader(hRequest, L"Accept: application/json") &&
+        setPredefinedHeadersFailed = TryAddHeader(hRequest, L"Accept: application/json") &&
             TryAddHeader(hRequest, L"Content-Type: application/json; charset=utf-8") &&
             TryAddHeader(hRequest, (L"X-PlayFabSDK: " + std::wstring(PlayFabSettings::versionString.begin(), PlayFabSettings::versionString.end())).c_str()) &&
             TryAddHeader(hRequest, L"X-ReportErrorAsSuccess: true");

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -200,7 +200,11 @@ namespace PlayFab
                                 if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
                                 {
                                     std::string header = obj.first + ": " + obj.second;
-                                    WinHttpAddRequestHeaders(hRequest, std::wstring(header.begin(), header.end()).c_str(), -1, 0);
+                                    HRESULT hHeaderAdd = WinHttpAddRequestHeaders(hRequest, std::wstring(header.begin(), header.end()).c_str(), -1, 0);
+                                    if(!hHeaderAdd)
+                                    {
+                                        SetErrorInfo(reqContainer, "Error in WinHttpAddRequestHeaders");
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
check for HRESULT when adding headers. WinHttpAddRequestHeaders can potentially fail in a few ways (out of memory for example). We don't handle this kind of issue at the moment.