### PR TITLE
Toddbell/event pipeline update

### DIFF
--- a/source/code/include/playfab/PlayFabEventApi.h
+++ b/source/code/include/playfab/PlayFabEventApi.h
@@ -29,6 +29,10 @@ namespace PlayFab
 
         void EmitEvent(std::unique_ptr<const IPlayFabEvent> event, std::function<void(std::shared_ptr<const IPlayFabEvent>, std::shared_ptr<const IPlayFabEmitEventResponse>)> callback) const;
 
+        /// <summary>
+        /// Updates the underlying event router which in turn will update the eventpipeline.
+        /// This function must be called every game tick if threadedEventPipeline is set to false
+        /// </summary>
         void Update();
 
     private:

--- a/source/code/include/playfab/PlayFabEventApi.h
+++ b/source/code/include/playfab/PlayFabEventApi.h
@@ -14,9 +14,7 @@ namespace PlayFab
     class PlayFabEventAPI
     {
     public:
-        PlayFabEventAPI(); // Default constructor
-
-        PlayFabEventAPI(bool threadedEventPipeline);
+        PlayFabEventAPI(bool threadedEventPipeline=true);
 
         std::shared_ptr<IPlayFabEventRouter> GetEventRouter() const;
 

--- a/source/code/include/playfab/PlayFabEventApi.h
+++ b/source/code/include/playfab/PlayFabEventApi.h
@@ -15,6 +15,9 @@ namespace PlayFab
     {
     public:
         PlayFabEventAPI(); // Default constructor
+
+        PlayFabEventAPI(bool threadedEventPipeline);
+
         std::shared_ptr<IPlayFabEventRouter> GetEventRouter() const;
 
         /// <summary>
@@ -25,6 +28,8 @@ namespace PlayFab
         void EmitEvent(std::unique_ptr<const IPlayFabEvent> event, const PlayFabEmitEventCallback callback) const;
 
         void EmitEvent(std::unique_ptr<const IPlayFabEvent> event, std::function<void(std::shared_ptr<const IPlayFabEvent>, std::shared_ptr<const IPlayFabEmitEventResponse>)> callback) const;
+
+        void Update();
 
     private:
         std::shared_ptr<IPlayFabEventRouter> eventRouter;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -74,8 +74,9 @@ namespace PlayFab
         PlayFabEventPipeline& operator=(PlayFabEventPipeline&& other) = delete; // disable move assignment
 
         // NOTE: settings are expected to be set prior to calling PlayFabEventPipeline::Start()
-        // changing them after PlayFabEventPipeline::Start() may cause threading issues
-        // users should not expect changes made to settings to take effect after ::Start is called unless the pipeline is destroyed and re-created
+        // changing them after PlayFabEventPipeline::Start() may cause threading issues unless you have set useBackgroundThread flag to true
+        // If this flag is not set, users should not expect changes made to settings to take effect after ::Start is called
+        //   unless the pipeline is A.) destroyed and re-created or B.) restart it by running Stop() and then Start() again 
         std::shared_ptr<PlayFabEventPipelineSettings> GetSettings() const;
         virtual void Start() override;
         virtual void Stop() override;
@@ -102,7 +103,6 @@ namespace PlayFab
         // that would allow to quickly map a pointer (like void* customData) to a batch (like a std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>).
         std::mutex inFlightMutex;
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
-        //std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -104,10 +104,6 @@ namespace PlayFab
     private:
         std::atomic_uintptr_t batchCounter;
         std::chrono::steady_clock::time_point momentBatchStarted;
-        std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
-
-        std::atomic_uintptr_t batchCounter;
-        std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
         PlayFabEventBuffer buffer;
         std::thread workerThread;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -102,6 +102,8 @@ namespace PlayFab
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
 
     private:
+        std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
+
         std::atomic_uintptr_t batchCounter;
         std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventPipelineSettings> settings;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -106,6 +106,8 @@ namespace PlayFab
         std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
 
+        std::atomic_uintptr_t batchCounter;
+        std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
         PlayFabEventBuffer buffer;
         std::thread workerThread;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -78,12 +78,14 @@ namespace PlayFab
         // users should not expect changes made to settings to take effect after ::Start is called unless the pipeline is destroyed and re-created
         std::shared_ptr<PlayFabEventPipelineSettings> GetSettings() const;
         virtual void Start() override;
+        virtual void Stop() override;
+        virtual void Update() override;
         virtual void IntakeEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) override;
 
         void SetExceptionCallback(ExceptionCallback callback);
 
     protected:
-        virtual void SendBatch();
+        virtual void SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch);
 
     private:
         void WorkerThread();
@@ -100,6 +102,7 @@ namespace PlayFab
         // that would allow to quickly map a pointer (like void* customData) to a batch (like a std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>).
         std::mutex inFlightMutex;
         std::unordered_map<void*, std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>> batchesInFlight;
+        //std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
     private:
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;

--- a/source/code/include/playfab/PlayFabEventRouter.h
+++ b/source/code/include/playfab/PlayFabEventRouter.h
@@ -41,7 +41,7 @@ namespace PlayFab
         PlayFabEventRouter(bool threadedEventPipeline);
         virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const;
 
-        void Update() override;
+        virtual void Update() override;
     private:
     };
 }

--- a/source/code/include/playfab/PlayFabEventRouter.h
+++ b/source/code/include/playfab/PlayFabEventRouter.h
@@ -41,6 +41,10 @@ namespace PlayFab
         PlayFabEventRouter(bool threadedEventPipeline);
         virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const;
 
+        /// <summary>
+        /// Updates underlying PlayFabEventPipeline
+        /// This function must be called every game tick if threadedEventPipeline is set to false
+        /// </summary>
         virtual void Update() override;
     private:
     };

--- a/source/code/include/playfab/PlayFabEventRouter.h
+++ b/source/code/include/playfab/PlayFabEventRouter.h
@@ -27,6 +27,7 @@ namespace PlayFab
         virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const = 0; // Route an event to pipelines. This method must be thread-safe.
         const std::unordered_map<EventPipelineKey, std::shared_ptr<IPlayFabEventPipeline>>& GetPipelines() const;
 
+        virtual void Update() = 0;
     protected:
         std::unordered_map<EventPipelineKey, std::shared_ptr<IPlayFabEventPipeline>> pipelines;
     };
@@ -37,8 +38,10 @@ namespace PlayFab
     class PlayFabEventRouter : public IPlayFabEventRouter
     {
     public:
-        PlayFabEventRouter();
+        PlayFabEventRouter(bool threadedEventPipeline);
         virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const;
+
+        void Update() override;
     private:
     };
 }

--- a/source/code/source/playfab/PlayFabEventApi.cpp
+++ b/source/code/source/playfab/PlayFabEventApi.cpp
@@ -7,8 +7,14 @@
 namespace PlayFab
 {
     PlayFabEventAPI::PlayFabEventAPI() :
-        eventRouter(std::make_shared<PlayFabEventRouter>()) // default event router
+        PlayFabEventAPI(true)
     {
+    }
+
+    PlayFabEventAPI::PlayFabEventAPI(bool threadedEventPipeline) : 
+        eventRouter(std::make_shared<PlayFabEventRouter>(threadedEventPipeline))
+    {
+        
     }
 
     std::shared_ptr<IPlayFabEventRouter> PlayFabEventAPI::GetEventRouter() const
@@ -34,6 +40,11 @@ namespace PlayFab
         eventRequest->stdCallback = callback;
 
         this->eventRouter->RouteEvent(eventRequest);
+    }
+    
+    void PlayFabEventAPI::Update()
+    {
+        this->eventRouter->Update();
     }
 }
 

--- a/source/code/source/playfab/PlayFabEventApi.cpp
+++ b/source/code/source/playfab/PlayFabEventApi.cpp
@@ -6,15 +6,9 @@
 
 namespace PlayFab
 {
-    PlayFabEventAPI::PlayFabEventAPI() :
-        PlayFabEventAPI(true)
-    {
-    }
-
     PlayFabEventAPI::PlayFabEventAPI(bool threadedEventPipeline) : 
         eventRouter(std::make_shared<PlayFabEventRouter>(threadedEventPipeline))
     {
-        
     }
 
     std::shared_ptr<IPlayFabEventRouter> PlayFabEventAPI::GetEventRouter() const

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -84,6 +84,12 @@ namespace PlayFab
 
     void PlayFabEventPipeline::Stop()
     {
+        if (!this->settings->useBackgroundThread)
+        {
+            LOG_PIPELINE("PlayFabEventPipeline is set to NOT use background threads. Stop() is not needed to be called then, but Update() is required to be manually called every tick in this case.");
+            return;
+        }
+
         if(!isWorkerThreadRunning)
         {
             LOG_PIPELINE("PlayFabEventPipeline has already been stopped, and should not be stopped again until Start() is called.");

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -270,10 +270,7 @@ namespace PlayFab
                     }
                 }
                 return false;
-                // event buffer is disabled or empty, and batch is not ready to be sent yet
-                // give some time back to CPU, don't starve it without a good reason
-                //std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime));
-            }
+                }
         }
         catch (const std::exception& ex)
         {
@@ -287,13 +284,12 @@ namespace PlayFab
                     userExceptionCallback(ex);
                 }
             } // UNLOCK userCallbackMutex
-            return false;
         }
         catch (...)
         {
             LOG_PIPELINE("A non std::exception was caught in PlayFabEventPipeline::WorkerThread method");
-            return false;
         }
+        return false;
     }
 
     void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch)

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -105,7 +105,7 @@ namespace PlayFab
             throw std::runtime_error("You should not call Update() when PlayFabEventPipelineSettings::useBackgroundThread == true");
         }
 
-        bool hasMoreWorkToProcess;
+        bool hasMoreWorkToProcess = false;
         do
         {
             hasMoreWorkToProcess = DoWork();

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -62,6 +62,18 @@ namespace PlayFab
 
     void PlayFabEventPipeline::Start()
     {
+        if (!this->settings->useBackgroundThread)
+        {
+            LOG_PIPELINE("PlayFabEventPipeline is set to NOT use background threads. Start() is not needed to be called then, but Update() is required to be manually called every tick in this case.");
+            return;
+        }
+
+        if(isWorkerThreadRunning)
+        {
+            LOG_PIPELINE("PlayFabEventPipeline has already been started, and should not be started again until Stop() is called.");
+            return;
+        }
+
         // start worker thread
         this->isWorkerThreadRunning = true;
         if (!this->workerThread.joinable())
@@ -72,6 +84,12 @@ namespace PlayFab
 
     void PlayFabEventPipeline::Stop()
     {
+        if(!isWorkerThreadRunning)
+        {
+            LOG_PIPELINE("PlayFabEventPipeline has already been stopped, and should not be stopped again until Start() is called.");
+            return;
+        }
+
         // stop worker thread
         this->isWorkerThreadRunning = false;
         if (this->workerThread.joinable())

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -223,7 +223,6 @@ namespace PlayFab
         using clock = std::chrono::steady_clock;
         using Result = PlayFabEventBuffer::EventConsumingResult;
         std::shared_ptr<const IPlayFabEmitEventRequest> request;
-
         std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
 
         try

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -248,10 +248,8 @@ namespace PlayFab
                         // if it is the first event in an incomplete batch then set the batch creation moment
                         momentBatchStarted = clock::now();
                     }
-
-                    continue; // immediately check if there is next event in buffer
+                    return true;
                 }
-                break;
 
                 case Result::Disabled:
                 case Result::Empty:
@@ -320,8 +318,6 @@ namespace PlayFab
             std::unique_lock<std::mutex> lock(inFlightMutex);
             this->batchesInFlight[customData] = std::move(batch);
         } // UNLOCK batchesInFlight
-        
-        batchCounter++;
 
         batch.clear(); // batch vector will be reused
         batch.reserve(this->settings->maximalNumberOfItemsInBatch);

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -225,7 +225,7 @@ namespace PlayFab
 
                 // Don't try taking a request until we get an entity token. We'd rather not lose events
                 // that were generated before an entity token was created (i.e. before a user was created).
-                if (PlayFabSettings::entityToken.empty() &&
+                if (PlayFabSettings::staticPlayer->entityToken.empty() &&
                     (settings->authenticationContext == nullptr || settings->authenticationContext->entityToken.empty()))
                 {
                     return false;
@@ -241,7 +241,7 @@ namespace PlayFab
                     // if batch is full
                     if (batch.size() >= this->settings->maximalNumberOfItemsInBatch)
                     {
-                        this->SendBatch();
+                        this->SendBatch(batch);
                     }
                     else if (batch.size() == 1)
                     {
@@ -265,7 +265,7 @@ namespace PlayFab
                     if (batchAge.count() >= (int32_t)this->settings->maximalBatchWaitTime)
                     {
                         // batch wait time expired, send incomplete batch
-                        this->SendBatch();
+                        this->SendBatch(batch);
                         return true;
                     }
                 }
@@ -296,7 +296,7 @@ namespace PlayFab
         }
     }
 
-    void PlayFabEventPipeline::SendBatch()
+    void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch)
     {
         // create a WriteEvents API request to send the batch
         EventsModels::WriteEventsRequest batchReq;

--- a/source/code/source/playfab/PlayFabEventRouter.cpp
+++ b/source/code/source/playfab/PlayFabEventRouter.cpp
@@ -11,10 +11,10 @@ namespace PlayFab
         return this->pipelines;
     }
 
-    PlayFabEventRouter::PlayFabEventRouter()
+    PlayFabEventRouter::PlayFabEventRouter(bool threadedEventPipeline)
     {
-        this->pipelines.emplace(EventPipelineKey::PlayFabPlayStream, std::make_shared<PlayFabEventPipeline>(std::make_shared<PlayFabEventPipelineSettings>(PlayFabEventPipelineType::PlayFabPlayStream)));
-        this->pipelines.emplace(EventPipelineKey::PlayFabTelemetry, std::make_shared<PlayFabEventPipeline>(std::make_shared<PlayFabEventPipelineSettings>(PlayFabEventPipelineType::PlayFabTelemetry)));
+        this->pipelines.emplace(EventPipelineKey::PlayFabPlayStream, std::make_shared<PlayFabEventPipeline>(std::make_shared<PlayFabEventPipelineSettings>(PlayFabEventPipelineType::PlayFabPlayStream, threadedEventPipeline)));
+        this->pipelines.emplace(EventPipelineKey::PlayFabTelemetry, std::make_shared<PlayFabEventPipeline>(std::make_shared<PlayFabEventPipelineSettings>(PlayFabEventPipelineType::PlayFabTelemetry, threadedEventPipeline)));
     }
 
     void PlayFabEventRouter::RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const
@@ -52,6 +52,14 @@ namespace PlayFab
                     }
                 }
             }
+        }
+    }
+    
+    void PlayFabEventRouter::Update()
+    {
+        for (std::pair<EventPipelineKey, std::shared_ptr<IPlayFabEventPipeline>> pipeline : this->pipelines)
+        {
+            pipeline.second->Update();
         }
     }
 }

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -68,6 +68,9 @@ namespace PlayFabUnit
 
         void GenericMultiThreadedTest(TestContext& testContext, uint32_t pNumThreads, uint32_t pNumEventsPerThread);
 
+        void TestQueueBeforeLogin(TestContext& testContext);
+        void OnQueingTestLogin(const PlayFab::ClientModels::LoginResult& result, void* customData);
+
         // State
         const int eventEmitCount = 6;
         size_t eventBatchMax;
@@ -77,11 +80,14 @@ namespace PlayFabUnit
         std::vector<std::thread> testThreadPool;
         std::vector<std::shared_ptr<PlayFab::PlayFabEventAPI>> eventApiPool;
         std::atomic<uint32_t> eventCounter;
+        std::atomic<uint32_t> queueTestCount = 0;
+        const uint32_t c_numQueueTestEvents = 4;
 
         // Utility
         void EmitEvents(TestContext& testContext, PlayFab::PlayFabEventType eventType, int maxBatchWaitTime = 2, int maxItemsInBatch = 3, int maxBatchesInFlight = 10);
         void EmitEventCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response);
         void NonStaticEmitEventCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response);
+        void QueueTestCallback(std::shared_ptr<const PlayFab::IPlayFabEvent> event, std::shared_ptr<const PlayFab::IPlayFabEmitEventResponse> response);
 
         template<typename T> std::function<void(const T&, void*)> ApiCallback(void(PlayFabEventTest::* func)(const T&, void*))
         {


### PR DESCRIPTION
There was a PR awhile back to a forked version of our project that seemed to be a good fit to port to our public codebase. This PR contains that fix. 

@ScottMunroMS was able to add a threaded callback flag to the event pipeline, enabling manual pumping functionality.

Scott's summary:

"this change updates the playfab event pipeline to allow manually pumping it's work queues instead of relying on over-active background threads.

doing so eliminates extra threads which we couldn't affinitize. Having fewer background threads and ensuring all of them are affinitizable will make AAA devs happy."