### PR TITLE
Toddbell/header handle xplat

### DIFF
--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -45,7 +45,7 @@ namespace PlayFab
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
 
     private:
-        void CurlHeaderFailed(std::unique_ptr<CallRequestContainer> requestContainer);
-        bool TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, const char* headerToAppend);
+        void CurlHeaderFailed(CallRequestContainer& requestContainer);
+        bool TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend);
     };
 }

--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -3,6 +3,7 @@
 #include <playfab/PlayFabCallRequestContainer.h>
 #include <playfab/PlayFabPluginManager.h>
 #include <playfab/PlayFabError.h>
+#include <curl/curl.h>
 #include <functional>
 #include <deque>
 #include <memory>

--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -45,7 +45,8 @@ namespace PlayFab
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
 
     private:
-        void CurlHeaderFailed(CallRequestContainer& requestContainer);
+        void CurlHeaderFailed(CallRequestContainer& requestContainer, const char* failedHeader);
+        curl_slist* SetPredefinedHeaders(CallRequestContainer& requestContainer);
         curl_slist* TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend);
     };
 }

--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -46,6 +46,6 @@ namespace PlayFab
 
     private:
         void CurlHeaderFailed(CallRequestContainer& requestContainer);
-        bool TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend);
+        curl_slist* TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend);
     };
 }

--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -42,5 +42,9 @@ namespace PlayFab
         int activeRequestCount;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingRequests;
         std::deque<std::unique_ptr<CallRequestContainerBase>> pendingResults;
+
+    private:
+        void CurlHeaderFailed(std::unique_ptr<CallRequestContainer> requestContainer);
+        bool TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, char* headerToAppend);
     };
 }

--- a/source/code/include/playfab/PlayFabCurlHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabCurlHttpPlugin.h
@@ -46,6 +46,6 @@ namespace PlayFab
 
     private:
         void CurlHeaderFailed(std::unique_ptr<CallRequestContainer> requestContainer);
-        bool TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, char* headerToAppend);
+        bool TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, const char* headerToAppend);
     };
 }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -333,7 +333,7 @@ namespace PlayFab
         list = curl_slist_append(list, headerToAppend);
         if(list == NULL)
         {
-            CurlHeaderFailed(std::move(requestContainer));
+            CurlHeaderFailed(requestContainer);
         }
         return list;
     }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -298,7 +298,7 @@ namespace PlayFab
         }
     }
 
-    curl_slist* PlayFabCurlHttpPlugin::SetPredefinedHeaders()
+    curl_slist* PlayFabCurlHttpPlugin::SetPredefinedHeaders(CallRequestContainer& reqContainer)
     {
         curl_slist* curlHttpHeaders = nullptr;
 

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -325,7 +325,7 @@ namespace PlayFab
         HandleCallback(std::move(requestContainer));
     }
 
-    bool PlayFabCurlHttpPlugin::TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, char* headerToAppend)
+    bool PlayFabCurlHttpPlugin::TryCurlAddHeader(std::unique_ptr<CallRequestContainer> requestContainer, curl_slist* list, const char* headerToAppend)
     {
         list = curl_slist_append(list, headerToAppend);
         if(list == NULL)

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -179,6 +179,15 @@ namespace PlayFab
                 {
                     std::string header = obj.first + ": " + obj.second;
                     curlHttpHeaders = curl_slist_append(curlHttpHeaders, header.c_str());
+                    if(curlHttpHeaders == NULL)
+                    {
+                        reqContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
+                        reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::UnknownError;
+                        reqContainer.errorWrapper.ErrorName = "Header Creation failed";
+                        reqContainer.errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
+                        HandleCallback(std::move(requestContainer));
+                        return;
+                    }
                 }
             }
         }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -318,10 +318,10 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::CurlHeaderFailed(std::unique_ptr<CallRequestContainer> requestContainer)
     {
-        reqContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
-        reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
-        reqContainer.errorWrapper.ErrorName = "Header Creation failed";
-        reqContainer.errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
+        requestContainer->errorWrapper.HttpStatus = "Failed to create Headers list";
+        requestContainer->errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
+        requestContainer->errorWrapper.ErrorName = "Header Creation failed";
+        requestContainer->errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
         HandleCallback(std::move(requestContainer));
     }
 

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -322,10 +322,10 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::CurlHeaderFailed(CallRequestContainer& requestContainer)
     {
-        requestContainer->errorWrapper.HttpStatus = "Failed to create Headers list";
-        requestContainer->errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
-        requestContainer->errorWrapper.ErrorName = "Header Creation failed";
-        requestContainer->errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
+        requestContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
+        requestContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
+        requestContainer.errorWrapper.ErrorName = "Header Creation failed";
+        requestContainer.errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
     }
 
     curl_slist* PlayFabCurlHttpPlugin::TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend)

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -2,7 +2,6 @@
 
 #include <playfab/PlayFabCurlHttpPlugin.h>
 #include <playfab/PlayFabSettings.h>
-#include <curl/curl.h>
 
 #include <stdexcept>
 

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -165,7 +165,7 @@ namespace PlayFab
         curl_slist* curlHttpHeaders = nullptr;
 
         curlHttpHeaders = TryCurlAddHeader(reqContainer, curlHttpHeaders, "Accept: application/json");
-        if(curlHttpHeaders == nullptr)
+        if (curlHttpHeaders == NULL)
         {
             HandleCallback(std::move(requestContainer));
             return;
@@ -178,7 +178,7 @@ namespace PlayFab
             return;
         }
 
-        curlHttpHeaders = TryCurlAddHeader(reqContainer, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
+        curlHttpHeaders = TryCurlAddHeader(reqContainer, curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
         if (curlHttpHeaders == NULL)
         {
             HandleCallback(std::move(requestContainer));
@@ -334,7 +334,6 @@ namespace PlayFab
         if(list == NULL)
         {
             CurlHeaderFailed(std::move(requestContainer));
-            return nullptr;
         }
         return list;
     }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -164,24 +164,24 @@ namespace PlayFab
         // Set up headers
         curl_slist* curlHttpHeaders = nullptr;
 
-        if(!TryCurlAddHeader(requestContainer, curlHttpHeaders, "Accept: application/json"))
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Accept: application/json"))
         {
             return;
         }
 
         //curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Accept: application/json");
 
-        if(!TryCurlAddHeader(requestContainer, curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
         {
             return;
         }
 
-        if(!TryCurlAddHeader(requestContainer, curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
         {
             return;
         }
 
-        if(!TryCurlAddHeader(curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
         {
             return;
         }
@@ -199,7 +199,7 @@ namespace PlayFab
                 if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
                 {
                     std::string header = obj.first + ": " + obj.second;
-                    if(!TryCurlAddHeader(requestContainer, curlHttpHeaders, header.c_str()))
+                    if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, header.c_str()))
                     {
                         return;
                     }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -164,31 +164,31 @@ namespace PlayFab
         // Set up headers
         curl_slist* curlHttpHeaders = nullptr;
 
-        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Accept: application/json"))
-        // {
-        //     return;
-        // }
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Accept: application/json"))
+        {
+            return;
+        }
 
 
-        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
-        // {
-        //     return;
-        // }
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
+        {
+            return;
+        }
 
-        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
-        // {
-        //     return;
-        // }
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
+        {
+            return;
+        }
 
-        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
-        // {
-        //     return;
-        // }
+        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
+        {
+            return;
+        }
 
-        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Accept: application/json");
-        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Content-Type: application/json; charset=utf-8");
-        curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
-        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
+        // curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Accept: application/json");
+        // curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Content-Type: application/json; charset=utf-8");
+        // curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
+        // curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
 
         const std::unordered_map<std::string, std::string> headers = reqContainer.GetRequestHeaders();
 
@@ -199,12 +199,12 @@ namespace PlayFab
                 if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
                 {
                     std::string header = obj.first + ": " + obj.second;
-                    curlHttpHeaders = curl_slist_append(curlHttpHeaders, header.c_str());
+                    //curlHttpHeaders = curl_slist_append(curlHttpHeaders, header.c_str());
 
-                    // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, header.c_str()))
-                    // {
-                    //     return;
-                    // }
+                    if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, header.c_str()))
+                    {
+                        return;
+                    }
                 }
             }
         }
@@ -240,7 +240,6 @@ namespace PlayFab
             reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorConnectionTimeout;
             reqContainer.errorWrapper.ErrorName = "Failed to contact server";
             reqContainer.errorWrapper.ErrorMessage = "Failed to contact server, curl error: " + std::to_string(res);
-            //HandleCallback(std::move(requestContainer));
         }
         else
         {
@@ -267,8 +266,6 @@ namespace PlayFab
                 reqContainer.errorWrapper.ErrorName = "Failed to parse PlayFab response";
                 reqContainer.errorWrapper.ErrorMessage = jsonParseErrors;
             }
-
-            //HandleCallback(std::move(requestContainer));
         }
 
         HandleCallback(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -312,11 +312,11 @@ namespace PlayFab
 
     void PlayFabCurlHttpPlugin::CurlHeaderFailed(CallRequestContainer& requestContainer, const char* failedHeader)
     {
+        std::string message = "Request failed initializing the header before sending the request. Failing out early. The Problematic Header: ";
         requestContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
         requestContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
         requestContainer.errorWrapper.ErrorName = "Header Creation Failed";
-        requestContainer.errorWrapper.ErrorMessage = "Request failed initializing the header before sending the request. Failing out early. The Problematic Header: ";
-        requestContainer.errorWrapper.ErrorMessage += failedHeader;
+        requestContainer.errorWrapper.ErrorMessage = message + failedHeader;
     }
 
     curl_slist* PlayFabCurlHttpPlugin::TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend)

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -315,7 +315,7 @@ namespace PlayFab
         requestContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
         requestContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
         requestContainer.errorWrapper.ErrorName = "Header Creation Failed";
-        requestContainer.errorWrapper.ErrorMessage = "Request failed initializing the header before sending the request. Failing out early. The Problematic Header: " + failedHeader;
+        requestContainer.errorWrapper.ErrorMessage = ("Request failed initializing the header before sending the request. Failing out early. The Problematic Header: " + failedHeader).c_str());
     }
 
     curl_slist* PlayFabCurlHttpPlugin::TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend)

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -164,31 +164,31 @@ namespace PlayFab
         // Set up headers
         curl_slist* curlHttpHeaders = nullptr;
 
-        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Accept: application/json"))
-        {
-            return;
-        }
+        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Accept: application/json"))
+        // {
+        //     return;
+        // }
 
-        //curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Accept: application/json");
 
-        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
-        {
-            return;
-        }
+        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "Content-Type: application/json; charset=utf-8"))
+        // {
+        //     return;
+        // }
 
-        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
-        {
-            return;
-        }
+        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str()))
+        // {
+        //     return;
+        // }
 
-        if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
-        {
-            return;
-        }
+        // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, "X-ReportErrorAsSuccess: true"))
+        // {
+        //     return;
+        // }
 
-        //curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Content-Type: application/json; charset=utf-8");
-        //curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
-        //curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
+        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Accept: application/json");
+        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "Content-Type: application/json; charset=utf-8");
+        curlHttpHeaders = curl_slist_append(curlHttpHeaders, ("X-PlayFabSDK: " + PlayFabSettings::versionString).c_str());
+        curlHttpHeaders = curl_slist_append(curlHttpHeaders, "X-ReportErrorAsSuccess: true");
 
         const std::unordered_map<std::string, std::string> headers = reqContainer.GetRequestHeaders();
 
@@ -238,7 +238,7 @@ namespace PlayFab
             reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorConnectionTimeout;
             reqContainer.errorWrapper.ErrorName = "Failed to contact server";
             reqContainer.errorWrapper.ErrorMessage = "Failed to contact server, curl error: " + std::to_string(res);
-            HandleCallback(std::move(requestContainer));
+            //HandleCallback(std::move(requestContainer));
         }
         else
         {
@@ -266,8 +266,10 @@ namespace PlayFab
                 reqContainer.errorWrapper.ErrorMessage = jsonParseErrors;
             }
 
-            HandleCallback(std::move(requestContainer));
+            //HandleCallback(std::move(requestContainer));
         }
+
+        HandleCallback(std::move(requestContainer));
 
         curl_slist_free_all(curlHttpHeaders);
         curlHttpHeaders = nullptr;

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -320,7 +320,7 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::CurlHeaderFailed(std::unique_ptr<CallRequestContainer> requestContainer)
     {
         reqContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
-        reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::UnknownError;
+        reqContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
         reqContainer.errorWrapper.ErrorName = "Header Creation failed";
         reqContainer.errorWrapper.ErrorMessage = "Request failed initializing before sending. Failing out early.";
         HandleCallback(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -199,10 +199,12 @@ namespace PlayFab
                 if (obj.first.length() != 0 && obj.second.length() != 0) // no empty keys or values in headers
                 {
                     std::string header = obj.first + ": " + obj.second;
-                    if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, header.c_str()))
-                    {
-                        return;
-                    }
+                    curlHttpHeaders = curl_slist_append(curlHttpHeaders, header.c_str());
+
+                    // if(!TryCurlAddHeader(std::move(requestContainer), curlHttpHeaders, header.c_str()))
+                    // {
+                    //     return;
+                    // }
                 }
             }
         }

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -315,7 +315,8 @@ namespace PlayFab
         requestContainer.errorWrapper.HttpStatus = "Failed to create Headers list";
         requestContainer.errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorUnkownError;
         requestContainer.errorWrapper.ErrorName = "Header Creation Failed";
-        requestContainer.errorWrapper.ErrorMessage = ("Request failed initializing the header before sending the request. Failing out early. The Problematic Header: " + failedHeader).c_str());
+        requestContainer.errorWrapper.ErrorMessage = "Request failed initializing the header before sending the request. Failing out early. The Problematic Header: ";
+        requestContainer.errorWrapper.ErrorMessage += failedHeader;
     }
 
     curl_slist* PlayFabCurlHttpPlugin::TryCurlAddHeader(CallRequestContainer& requestContainer, curl_slist* list, const char* headerToAppend)


### PR DESCRIPTION
Curl http plugin is missing header-adding error-handling logic (if we add a header and run out of memory, we need to gracefully handle the issue and stop attempting to send out a broken request).