### PR TITLE
Fixes Android's Clang Warnings

### DIFF
--- a/source/code/include/playfab/PlayFabEventRouter.h
+++ b/source/code/include/playfab/PlayFabEventRouter.h
@@ -39,7 +39,7 @@ namespace PlayFab
     {
     public:
         PlayFabEventRouter(bool threadedEventPipeline);
-        virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const;
+        virtual void RouteEvent(std::shared_ptr<const IPlayFabEmitEventRequest> request) const override;
 
         /// <summary>
         /// Updates underlying PlayFabEventPipeline

--- a/source/test/TestApp/PlayFabEventTest.h
+++ b/source/test/TestApp/PlayFabEventTest.h
@@ -80,7 +80,7 @@ namespace PlayFabUnit
         std::vector<std::thread> testThreadPool;
         std::vector<std::shared_ptr<PlayFab::PlayFabEventAPI>> eventApiPool;
         std::atomic<uint32_t> eventCounter;
-        std::atomic<uint32_t> queueTestCount = 0;
+        std::atomic<uint32_t> queueTestCount;
         const uint32_t c_numQueueTestEvents = 4;
 
         // Utility


### PR DESCRIPTION
This seems to also fix most other platform issues, but I ran into AppCenter problems later in the afternoon.