### PR TITLE
Toddbell/threaded callbacks fix

### DIFF
--- a/source/code/include/playfab/PlayFabCallRequestContainer.h
+++ b/source/code/include/playfab/PlayFabCallRequestContainer.h
@@ -27,7 +27,7 @@ namespace PlayFab
         std::shared_ptr<PlayFabAuthenticationContext> GetContext() const;
         std::string GetRequestId() const;
         void SetRequestId(const std::string& newRequestId);
-        bool HandleInvalidSettings();
+        void ThrowIfSettingsInvalid();
 
         // TODO: clean up these public variables with setters/getters when you have the chance.
 

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -248,8 +248,7 @@ namespace PlayFab
     void PlayFabAndroidHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        // Option C step 1
-        if (container != nullptr)// && container->HandleInvalidSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
@@ -405,11 +404,6 @@ namespace PlayFab
     bool PlayFabAndroidHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
-        // Option C step 2
-        if(!requestContainer.HandleInvalidSettings())
-        {
-            return false;
-        }
 
         JNIEnv* jniEnv = requestTask.impl->JniEvn();
         if (jniEnv == nullptr)

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -248,8 +248,9 @@ namespace PlayFab
     void PlayFabAndroidHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        if (container != nullptr)
         {
+            container->ThrowIfSettingsInvalid();
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
             {

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -248,7 +248,8 @@ namespace PlayFab
     void PlayFabAndroidHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        // Option C step 1
+        if (container != nullptr)// && container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
@@ -404,6 +405,11 @@ namespace PlayFab
     bool PlayFabAndroidHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
+        // Option C step 2
+        if(requestContainer.HandleInvalidSettings())
+        {
+            return false;
+        }
 
         JNIEnv* jniEnv = requestTask.impl->JniEvn();
         if (jniEnv == nullptr)

--- a/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabAndroidHttpPlugin.cpp
@@ -406,7 +406,7 @@ namespace PlayFab
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
         // Option C step 2
-        if(requestContainer.HandleInvalidSettings())
+        if(!requestContainer.HandleInvalidSettings())
         {
             return false;
         }

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -77,32 +77,10 @@ namespace PlayFab
 
     bool CallRequestContainer::HandleInvalidSettings()
     {
-        bool isValid = true;
         if (m_settings->titleId.empty())
         {
-            // Option B
-            //throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
-
-            errorWrapper.HttpCode = 0;
-            errorWrapper.HttpStatus = "Client-side validation failure";
-            errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
-            errorWrapper.ErrorName = errorWrapper.HttpStatus;
-            errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
-            isValid = false;
+            throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
         }
-
-        if (!isValid)
-        {
-            if (PlayFabSettings::globalErrorHandler != nullptr)
-            {
-                PlayFabSettings::globalErrorHandler(errorWrapper, GetCustomData());
-            }
-            if (errorCallback != nullptr)
-            {
-                errorCallback(errorWrapper, GetCustomData());
-            }
-        }
-
-        return isValid;
+        return true;
     }
 }

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -75,12 +75,11 @@ namespace PlayFab
         this->errorWrapper.RequestId = newRequestId;
     }
 
-    bool CallRequestContainer::HandleInvalidSettings()
+    void CallRequestContainer::ThrowIfSettingsInvalid()
     {
         if (m_settings->titleId.empty())
         {
             throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
         }
-        return true;
     }
 }

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -81,14 +81,14 @@ namespace PlayFab
         if (m_settings->titleId.empty())
         {
             // Option B
-            throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
+            //throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
 
-            // errorWrapper.HttpCode = 0;
-            // errorWrapper.HttpStatus = "Client-side validation failure";
-            // errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
-            // errorWrapper.ErrorName = errorWrapper.HttpStatus;
-            // errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
-            // isValid = false;
+            errorWrapper.HttpCode = 0;
+            errorWrapper.HttpStatus = "Client-side validation failure";
+            errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
+            errorWrapper.ErrorName = errorWrapper.HttpStatus;
+            errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
+            isValid = false;
         }
 
         if (!isValid)

--- a/source/code/source/playfab/PlayFabCallRequestContainer.cpp
+++ b/source/code/source/playfab/PlayFabCallRequestContainer.cpp
@@ -80,12 +80,15 @@ namespace PlayFab
         bool isValid = true;
         if (m_settings->titleId.empty())
         {
-            errorWrapper.HttpCode = 0;
-            errorWrapper.HttpStatus = "Client-side validation failure";
-            errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
-            errorWrapper.ErrorName = errorWrapper.HttpStatus;
-            errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
-            isValid = false;
+            // Option B
+            throw new PlayFabException(PlayFabExceptionCode::TitleNotSet, "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.");
+
+            // errorWrapper.HttpCode = 0;
+            // errorWrapper.HttpStatus = "Client-side validation failure";
+            // errorWrapper.ErrorCode = PlayFabErrorCode::PlayFabErrorInvalidParams;
+            // errorWrapper.ErrorName = errorWrapper.HttpStatus;
+            // errorWrapper.ErrorMessage = "PlayFabSettings::staticSettings->titleId has not been set properly. It must not be empty.";
+            // isValid = false;
         }
 
         if (!isValid)

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -60,11 +60,10 @@ namespace PlayFab
                     continue;
                 }
 
-                // Option C Step 2
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
+                    if (requestContainerPtr != nullptr)
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -111,8 +110,7 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        // Option C step 1
-        if (container != nullptr)// && container->HandleInvalidSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -60,10 +60,11 @@ namespace PlayFab
                     continue;
                 }
 
+                // Option C Step 2
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    if (requestContainerPtr != nullptr)
+                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -110,7 +111,8 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        // Option C step 1
+        if (container != nullptr)// && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabCurlHttpPlugin.cpp
@@ -110,8 +110,10 @@ namespace PlayFab
     void PlayFabCurlHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
-        { // LOCK httpRequestMutex
+        if (container != nullptr)
+        {
+            container->ThrowIfSettingsInvalid();
+             // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
             activeRequestCount++;

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -223,7 +223,7 @@ namespace PlayFab
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
         // Option C step 2
-        if(requestContainer.HandleInvalidSettings())
+        if(!requestContainer.HandleInvalidSettings())
         {
             return;
         }

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -96,8 +96,9 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        if (container != nullptr)
         {
+            container->ThrowIfSettingsInvalid();
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
             {

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -96,8 +96,7 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        // Option C step 1
-        if (container != nullptr)// && container->HandleInvalidSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
@@ -222,11 +221,6 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
-        // Option C step 2
-        if(!requestContainer.HandleInvalidSettings())
-        {
-            return;
-        }
 
         const auto& requestUrl = GetUrl(requestTask);
 

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -96,7 +96,8 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        // Option C step 1
+        if (container != nullptr)// && container->HandleInvalidSettings())
         {
             std::shared_ptr<RequestTask> requestTask = nullptr;
             try
@@ -221,6 +222,12 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
+        // Option C step 2
+        if(requestContainer.HandleInvalidSettings())
+        {
+            return;
+        }
+
         const auto& requestUrl = GetUrl(requestTask);
 
         NSURL* url = [NSURL URLWithString:[NSString stringWithUTF8String:requestUrl.c_str()]];

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -221,7 +221,6 @@ namespace PlayFab
     void PlayFabIOSHttpPlugin::ExecuteRequest(RequestTask& requestTask)
     {
         CallRequestContainer& requestContainer = requestTask.RequestContainer();
-
         const auto& requestUrl = GetUrl(requestTask);
 
         NSURL* url = [NSURL URLWithString:[NSString stringWithUTF8String:requestUrl.c_str()]];

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -96,8 +96,10 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
-        { // LOCK httpRequestMutex
+        if (container != nullptr)
+        {
+            container->ThrowIfSettingsInvalid();
+            // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
             activeRequestCount++;

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -57,7 +57,8 @@ namespace PlayFab
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    if (requestContainerPtr != nullptr)
+                    // Option C step 2
+                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -96,7 +97,8 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        // Option C step 1
+        if (container != nullptr)// && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabIXHR2HttpPlugin.cpp
@@ -57,8 +57,7 @@ namespace PlayFab
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    // Option C step 2
-                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
+                    if (requestContainerPtr != nullptr)
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -97,8 +96,7 @@ namespace PlayFab
     void PlayFabIXHR2HttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        // Option C step 1
-        if (container != nullptr)// && container->HandleInvalidSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -5,8 +5,7 @@
 namespace PlayFab
 {
     // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
-    // OPTION A-1 - If the title id is not set, the error callback will be synchronosly called within your failing api call.
-    //        B     ANY api call may synchronously throw an exception if the title id is not set
+    // Note ANY api call may synchronously throw an exception if the title id is not set, regardless of this flag
     bool PlayFabSettings::threadedCallbacks = false;
     const std::string PlayFabSettings::sdkVersion = "<%- sdkVersion %>";
     const std::string PlayFabSettings::buildIdentifier = "<%- buildIdentifier %>";

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -5,6 +5,8 @@
 namespace PlayFab
 {
     // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
+    // OPTION A-1 - If the title id is not set, the error callback will be synchronosly called within your failing api call.
+    //        B     ANY api call may synchronously throw an exception if the title id is not set
     bool PlayFabSettings::threadedCallbacks = false;
     const std::string PlayFabSettings::sdkVersion = "<%- sdkVersion %>";
     const std::string PlayFabSettings::buildIdentifier = "<%- buildIdentifier %>";

--- a/source/code/source/playfab/PlayFabSettings.cpp.ejs
+++ b/source/code/source/playfab/PlayFabSettings.cpp.ejs
@@ -5,7 +5,7 @@
 namespace PlayFab
 {
     // Control whether all callbacks are threaded or whether the user manually controls callback timing from their main-thread
-    // Note ANY api call may synchronously throw an exception if the title id is not set, regardless of this flag
+    // Note ANY api call may synchronously throw an exception if the title id is not set
     bool PlayFabSettings::threadedCallbacks = false;
     const std::string PlayFabSettings::sdkVersion = "<%- sdkVersion %>";
     const std::string PlayFabSettings::buildIdentifier = "<%- buildIdentifier %>";

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -59,11 +59,10 @@ namespace PlayFab
                     continue;
                 }
 
-                // Option C step 2
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
+                    if (requestContainerPtr != nullptr)
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -102,8 +101,7 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        // Option C Step 1
-        if (container != nullptr)// && container->HandleInvalidSettings())
+        if (container != nullptr && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -101,8 +101,10 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
-        { // LOCK httpRequestMutex
+        if (container != nullptr)
+        {
+            container->ThrowIfSettingsInvalid();
+            // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));
             activeRequestCount++;

--- a/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
+++ b/source/code/source/playfab/PlayFabWinHttpPlugin.cpp
@@ -59,10 +59,11 @@ namespace PlayFab
                     continue;
                 }
 
+                // Option C step 2
                 if (requestContainer != nullptr)
                 {
                     CallRequestContainer* requestContainerPtr = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-                    if (requestContainerPtr != nullptr)
+                    if (requestContainerPtr != nullptr && requestContainerPtr->HandleInvalidSettings())
                     {
                         requestContainer.release();
                         ExecuteRequest(std::unique_ptr<CallRequestContainer>(requestContainerPtr));
@@ -101,7 +102,8 @@ namespace PlayFab
     void PlayFabWinHttpPlugin::MakePostRequest(std::unique_ptr<CallRequestContainerBase> requestContainer)
     {
         CallRequestContainer* container = dynamic_cast<CallRequestContainer*>(requestContainer.get());
-        if (container != nullptr && container->HandleInvalidSettings())
+        // Option C Step 1
+        if (container != nullptr)// && container->HandleInvalidSettings())
         { // LOCK httpRequestMutex
             std::unique_lock<std::mutex> lock(httpRequestMutex);
             pendingRequests.push_back(std::move(requestContainer));


### PR DESCRIPTION
We may potentially throw an error synchronously, even if threaded Callbacks is set to false. There are 3 optional fixes:

A.) comment the behavior (we will synchronously call back the error if we know the http request will fail)
B.) Throw an exception (smallest possible change)
C.) Move HandleInvalidSettings after queuing the request (appropriate fix, but has the highest surface area change). 