### PR TITLE
Toddbell/ios fix

### DIFF
--- a/source/code/include/playfab/PlayFabIOSHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIOSHttpPlugin.h
@@ -50,7 +50,7 @@ namespace PlayFab
                 Requesting,
                 Finished
             };
-            
+
             CallRequestContainer& RequestContainer()
             {
                 return *dynamic_cast<CallRequestContainer*>(requestContainer.get());
@@ -66,7 +66,7 @@ namespace PlayFab
                 return requestContainer->GetUrl();
             }
 
-            std::string GetRequetsContainerFullUrl() const
+            std::string GetRequestContainerFullUrl() const
             {
                 return ConstRequestContainer().GetFullUrl();
             }

--- a/source/code/include/playfab/PlayFabIOSHttpPlugin.h
+++ b/source/code/include/playfab/PlayFabIOSHttpPlugin.h
@@ -50,14 +50,27 @@ namespace PlayFab
                 Requesting,
                 Finished
             };
+            
             CallRequestContainer& RequestContainer()
             {
                 return *dynamic_cast<CallRequestContainer*>(requestContainer.get());
             }
+
+            const CallRequestContainer& ConstRequestContainer() const
+            {
+                return *dynamic_cast<CallRequestContainer*>(requestContainer.get());
+            }
+
             std::string GetRequestContainerUrl() const
             {
                 return requestContainer->GetUrl();
             }
+
+            std::string GetRequetsContainerFullUrl() const
+            {
+                return ConstRequestContainer().GetFullUrl();
+            }
+
             void Cancel();
             std::atomic<State> state;
             std::unique_ptr<CallRequestContainerBase> requestContainer;

--- a/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
+++ b/source/code/source/playfab/PlayFabIOSHttpPlugin.mm
@@ -286,7 +286,7 @@ namespace PlayFab
 
     std::string PlayFabIOSHttpPlugin::GetUrl(const RequestTask& requestTask) const
     {
-        return requestTask.GetRequestContainerUrl();
+        return requestTask.GetRequestContainerFullUrl();
     }
 
     void PlayFabIOSHttpPlugin::SetPredefinedHeaders(const RequestTask& requestTask, void* urlRequest)


### PR DESCRIPTION
iOS GetUrl() returns only the last part of the url. 

Windows calls "GetFullUrl" which works. Android/Curl/etc. implements the GetUrl in the same way as iOS (ask the request container for its url) BUT the implementation never actually calls this particular GetUrl function (but rather, just get the container's request url directly)