### PR TITLE
Moved batch so that state was retained beween DoWork calls

### DIFF
--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -90,7 +90,7 @@ namespace PlayFab
 
     private:
         void WorkerThread();
-        bool DoWork();
+        bool DoWork(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, std::chrono::steady_clock::time_point& momentBatchStarted);
         void WriteEventsApiCallback(const EventsModels::WriteEventsResponse& result, void* customData);
         void WriteEventsApiErrorCallback(const PlayFabError& error, void* customData);
         void CallbackRequest(std::shared_ptr<const IPlayFabEmitEventRequest> request, std::shared_ptr<const IPlayFabEmitEventResponse> response);
@@ -108,7 +108,6 @@ namespace PlayFab
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
 
         std::atomic_uintptr_t batchCounter;
-        std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
         PlayFabEventBuffer buffer;
         std::thread workerThread;

--- a/source/code/include/playfab/PlayFabEventPipeline.h
+++ b/source/code/include/playfab/PlayFabEventPipeline.h
@@ -90,7 +90,7 @@ namespace PlayFab
 
     private:
         void WorkerThread();
-        bool DoWork(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, std::chrono::steady_clock::time_point& momentBatchStarted);
+        bool DoWork();
         void WriteEventsApiCallback(const EventsModels::WriteEventsResponse& result, void* customData);
         void WriteEventsApiErrorCallback(const PlayFabError& error, void* customData);
         void CallbackRequest(std::shared_ptr<const IPlayFabEmitEventRequest> request, std::shared_ptr<const IPlayFabEmitEventResponse> response);
@@ -108,6 +108,8 @@ namespace PlayFab
         std::shared_ptr<PlayFabEventsInstanceAPI> eventsApi;
 
         std::atomic_uintptr_t batchCounter;
+        std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
+        std::chrono::steady_clock::time_point momentBatchStarted;
         std::shared_ptr<PlayFabEventPipelineSettings> settings;
         PlayFabEventBuffer buffer;
         std::thread workerThread;

--- a/source/code/source/playfab/PlayFabEventPipeline.cpp
+++ b/source/code/source/playfab/PlayFabEventPipeline.cpp
@@ -84,6 +84,12 @@ namespace PlayFab
 
     void PlayFabEventPipeline::Stop()
     {
+        // flush remaining events
+        if (this->batch.size() > 0)
+        {
+            this->SendBatch(this->batch);
+        }
+
         if (!this->settings->useBackgroundThread)
         {
             LOG_PIPELINE("PlayFabEventPipeline is set to NOT use background threads. Stop() is not needed to be called then, but Update() is required to be manually called every tick in this case.");
@@ -111,21 +117,11 @@ namespace PlayFab
             throw std::runtime_error("You should not call Update() when PlayFabEventPipelineSettings::useBackgroundThread == true");
         }
 
-        std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
-        std::chrono::steady_clock::time_point momentBatchStarted;
-
         bool hasMoreWorkToProcess = false;
         do
         {
-            hasMoreWorkToProcess = DoWork(batch, momentBatchStarted);
+            hasMoreWorkToProcess = DoWork();
         } while (hasMoreWorkToProcess);
-
-        if( batch.size() > 0)
-        {   
-            // Flush remaining events.
-            this->SendBatch(batch);            
-        }
-
     }
 
     // NOTE: settings are expected to be set prior to calling PlayFabEventPipeline::Start()
@@ -217,12 +213,11 @@ namespace PlayFab
 
     void PlayFabEventPipeline::WorkerThread()
     {
-        std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>> batch;
-        std::chrono::steady_clock::time_point momentBatchStarted;
+        using clock = std::chrono::steady_clock;
 
         while (this->isWorkerThreadRunning)
         {
-            bool hasMoreWorkToProcess = DoWork(batch, momentBatchStarted);
+            bool hasMoreWorkToProcess = DoWork();
 
             if (!hasMoreWorkToProcess)
             {
@@ -230,14 +225,14 @@ namespace PlayFab
                 std::this_thread::sleep_for(std::chrono::milliseconds(this->settings->readBufferWaitTime));
             }
         }
-        if( batch.size() > 0)
-        {   
+        if( this->batch.size() > 0)
+        {
             // Flush remaining events on shutdown
-            this->SendBatch(batch);            
+            this->SendBatch(this->batch);            
         }
     }
 
-    bool PlayFabEventPipeline::DoWork(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch, std::chrono::steady_clock::time_point& momentBatchStarted)
+    bool PlayFabEventPipeline::DoWork()
     {
         using clock = std::chrono::steady_clock;
         using Result = PlayFabEventBuffer::EventConsumingResult;
@@ -245,7 +240,7 @@ namespace PlayFab
 
         try
         {
-            batch.reserve(this->settings->maximalNumberOfItemsInBatch);
+            this->batch.reserve(this->settings->maximalNumberOfItemsInBatch);
         
             while (this->isWorkerThreadRunning)
             {
@@ -277,18 +272,18 @@ namespace PlayFab
                 case Result::Success:
                 {
                     // add an event to batch
-                    batch.push_back(std::move(request));
+                    this->batch.push_back(std::move(request));
 
-                    if (batch.size() == 1)
+                    if (this->batch.size() == 1)
                     {
                         // if it is the first event in an incomplete batch then set the batch creation moment
-                        momentBatchStarted = clock::now();
+                        this->momentBatchStarted = clock::now();
                     }
                     
-                    if (batch.size() >= this->settings->maximalNumberOfItemsInBatch)
+                    if (this->batch.size() >= this->settings->maximalNumberOfItemsInBatch)
                     {
                         // if batch is full
-                        this->SendBatch(batch);
+                        this->SendBatch(this->batch);
                     }
                     return true;
                 }
@@ -300,14 +295,14 @@ namespace PlayFab
                 }
 
                 // if batch was started
-                if (batch.size() > 0)
+                if (this->batch.size() > 0)
                 {
                     // check if the batch wait time expired
-                    std::chrono::seconds batchAge = std::chrono::duration_cast<std::chrono::seconds>(clock::now() - momentBatchStarted);
+                    std::chrono::seconds batchAge = std::chrono::duration_cast<std::chrono::seconds>(clock::now() - this->momentBatchStarted);
                     if (batchAge.count() >= (int32_t)this->settings->maximalBatchWaitTime)
                     {
                         // batch wait time expired, send incomplete batch
-                        this->SendBatch(batch);
+                        this->SendBatch(this->batch);
                         return true;
                     }
                 }
@@ -334,7 +329,7 @@ namespace PlayFab
         return false;
     }
 
-    void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& batch)
+    void PlayFabEventPipeline::SendBatch(std::vector<std::shared_ptr<const IPlayFabEmitEventRequest>>& localbatch)
     {
         // create a WriteEvents API request to send the batch
         EventsModels::WriteEventsRequest batchReq;
@@ -343,7 +338,7 @@ namespace PlayFab
             batchReq.authenticationContext = this->settings->authenticationContext;
         }
 
-        for (const auto& eventEmitRequest : batch)
+        for (const auto& eventEmitRequest : localbatch)
         {
             const auto& playFabEmitRequest = std::dynamic_pointer_cast<const PlayFabEmitEventRequest>(eventEmitRequest);
             batchReq.Events.push_back(playFabEmitRequest->event->eventContents);
@@ -354,11 +349,11 @@ namespace PlayFab
 
         { // LOCK batchesInFlight mutex
             std::unique_lock<std::mutex> lock(inFlightMutex);
-            this->batchesInFlight[customData] = std::move(batch);
+            this->batchesInFlight[customData] = std::move(localbatch);
         } // UNLOCK batchesInFlight
 
-        batch.clear(); // batch vector will be reused
-        batch.reserve(this->settings->maximalNumberOfItemsInBatch);
+        localbatch.clear(); // batch vector will be reused
+        localbatch.reserve(this->settings->maximalNumberOfItemsInBatch);
         if (this->settings->emitType == PlayFabEventPipelineType::PlayFabPlayStream)
         {
             // call Events API to send the batch


### PR DESCRIPTION
Moved batch container up one step in the callstack to retain state between calls when using background threads.
Explicit ::Update() call path flushes any partial batches before exiting.