### PR TITLE
Update com.playfab.xplatcppsdk.v141.nuspec.ejs

### DIFF
--- a/source/com.playfab.xplatcppsdk.v141.nuspec.ejs
+++ b/source/com.playfab.xplatcppsdk.v141.nuspec.ejs
@@ -16,9 +16,12 @@
     </metadata>
     <files>
         <file src=".\com.playfab.xplatcppsdk.<%- vsVer %>.targets" target="build\native\com.playfab.xplatcppsdk.<%- vsVer %>.targets" />
-        <file src=".\external\jsoncpp-build\x64\$configuration$\lib_json.lib" target="build\native\lib\$configuration$\lib_json.lib" />
+        <file src=".\external\jsoncpp-build\x64\$configuration$\lib_json.lib" target="build\native\lib\x64\$configuration$\lib_json.lib" />
+        <file src=".\external\jsoncpp-build\x64\Debug\lib_json.lib" target="build\native\lib\x64\Debug\lib_json.lib" />
         <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.pdb" target="build\native\lib\$configuration$\XPlatCppWindows.pdb" />
         <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.lib" target="build\native\lib\$configuration$\XPlatCppWindows.lib" />
+        <file src=".\build\Windows\x64\Debug\XPlatCppWindows\XPlatCppWindows.pdb" target="build\native\lib\x64\Debug\XPlatCppWindows.pdb" />
+        <file src=".\build\Windows\x64\Debug\XPlatCppWindows\XPlatCppWindows.lib" target="build\native\lib\x64\Debug\XPlatCppWindows.lib" />
         <file src=".\code\include\playfab\**\*.h" target="build\native\include\playfab" />
         <file src=".\external\jsoncpp\include\json\**\*.h" target="build\native\include\json" />
     </files>

--- a/source/com.playfab.xplatcppsdk.v141.nuspec.ejs
+++ b/source/com.playfab.xplatcppsdk.v141.nuspec.ejs
@@ -18,8 +18,8 @@
         <file src=".\com.playfab.xplatcppsdk.<%- vsVer %>.targets" target="build\native\com.playfab.xplatcppsdk.<%- vsVer %>.targets" />
         <file src=".\external\jsoncpp-build\x64\$configuration$\lib_json.lib" target="build\native\lib\x64\$configuration$\lib_json.lib" />
         <file src=".\external\jsoncpp-build\x64\Debug\lib_json.lib" target="build\native\lib\x64\Debug\lib_json.lib" />
-        <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.pdb" target="build\native\lib\$configuration$\XPlatCppWindows.pdb" />
-        <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.lib" target="build\native\lib\$configuration$\XPlatCppWindows.lib" />
+        <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.pdb" target="build\native\lib\x64\$configuration$\XPlatCppWindows.pdb" />
+        <file src=".\build\Windows\x64\$configuration$\XPlatCppWindows\XPlatCppWindows.lib" target="build\native\lib\x64\$configuration$\XPlatCppWindows.lib" />
         <file src=".\build\Windows\x64\Debug\XPlatCppWindows\XPlatCppWindows.pdb" target="build\native\lib\x64\Debug\XPlatCppWindows.pdb" />
         <file src=".\build\Windows\x64\Debug\XPlatCppWindows\XPlatCppWindows.lib" target="build\native\lib\x64\Debug\XPlatCppWindows.lib" />
         <file src=".\code\include\playfab\**\*.h" target="build\native\include\playfab" />


### PR DESCRIPTION
Going to hard code debug libs since we build them in the process anyway. 

The old autopackager file from CoApp (no longer supported http://coapp.org/) was able to differentiate Debug vs Release files within their own scope. I'm forcing our (supported) nuspec file to expect the same Debug libraries to exist when calling nuget pack in the supported fashion. 

Out of Scope:
1.) we are not updating to v142 (this would change various parts of our build pipeline, this would need a brand new nuspec file and new upload location on nuget.org with the new title)
2.) we are not adding support for x86 (we are adding this specific hard coding to the path)