### PR TITLE
Auth GameServer EntityToken caching & deleting

### DIFF
--- a/make.js
+++ b/make.js
@@ -152,7 +152,7 @@ function hasAuthParams(apiCall) {
 }
 
 function getAuthParams(apiCall, isInstanceApi) {
-    if (apiCall.url === "/Authentication/GetEntityToken"  || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.url === "/Authentication/GetEntityToken")
         return "authKey, authValue";
     switch (apiCall.auth) {
         case "EntityToken": return "\"X-EntityToken\", context->entityToken";
@@ -316,7 +316,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "}\n";
         return result;
     }
-    if (apiCall.url === "/Authentication/GetEntityToken"  || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+    if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "std::string authKey, authValue;\n" +
             tabbing + "if (context->entityToken.length() > 0)\n" +
             tabbing + "{\n" +
@@ -340,9 +340,7 @@ function getResultActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.Entity->Id, outResult.Entity->Type, outResult.EntityToken);\n";
     if (apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
-        return tabbing + "context->HandlePlayFabGameServerLogin(\"\", \"\", outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n";
-    if (apiCall.url === "/GameServerIdentity/Delete")
-        return tabbing + "context->HandlePlayFabGameServerLogin(\"\", \"\", \"\", \"\", \"\");\n";
+        return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n";
     if (apiCall.result === "LoginResult")
         return tabbing + "\n" 
             + tabbing + "outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n"

--- a/make.js
+++ b/make.js
@@ -152,7 +152,7 @@ function hasAuthParams(apiCall) {
 }
 
 function getAuthParams(apiCall, isInstanceApi) {
-    if (apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.url === "/Authentication/GetEntityToken"  || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         return "authKey, authValue";
     switch (apiCall.auth) {
         case "EntityToken": return "\"X-EntityToken\", context->entityToken";
@@ -316,7 +316,7 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
             + tabbing + "}\n";
         return result;
     }
-    if (apiCall.url === "/Authentication/GetEntityToken")
+    if (apiCall.url === "/Authentication/GetEntityToken"  || apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
         return tabbing + "std::string authKey, authValue;\n" +
             tabbing + "if (context->entityToken.length() > 0)\n" +
             tabbing + "{\n" +
@@ -339,6 +339,8 @@ function getRequestActions(tabbing, apiCall, isInstanceApi) {
 function getResultActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.Entity->Id, outResult.Entity->Type, outResult.EntityToken);\n";
+    if (apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
+        return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n";
     if (apiCall.result === "LoginResult")
         return tabbing + "\n" 
             + tabbing + "outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n"

--- a/make.js
+++ b/make.js
@@ -340,7 +340,9 @@ function getResultActions(tabbing, apiCall, isInstanceApi) {
     if (apiCall.url === "/Authentication/GetEntityToken")
         return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.Entity->Id, outResult.Entity->Type, outResult.EntityToken);\n";
     if (apiCall.url === "/GameServerIdentity/AuthenticateGameServerWithCustomId")
-        return tabbing + "context->HandlePlayFabLogin(\"\", \"\", outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n";
+        return tabbing + "context->HandlePlayFabGameServerLogin(\"\", \"\", outResult.EntityToken->Entity->Id, outResult.EntityToken->Entity->Type, outResult.EntityToken->EntityToken);\n";
+    if (apiCall.url === "/GameServerIdentity/Delete")
+        return tabbing + "context->HandlePlayFabGameServerLogin(\"\", \"\", \"\", \"\", \"\");\n";
     if (apiCall.result === "LoginResult")
         return tabbing + "\n" 
             + tabbing + "outResult.authenticationContext = std::make_shared<PlayFabAuthenticationContext>();\n"

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp.ejs
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp.ejs
@@ -45,6 +45,21 @@
             SetIfNotNull(_entityType, entityType);
             SetIfNotNull(_entityToken, entityToken);
         }
+
+        void PlayFabAuthenticationContext::HandlePlayFabGameServerLogin(
+            const std::string& _playFabId,
+            const std::string& _clientSessionTicket,
+            const std::string& _entityId,
+            const std::string& _entityType,
+            const std::string& _entityToken
+        )
+        {
+            SetIfNotNull(_playFabId, playFabId);
+            SetIfNotNull(_clientSessionTicket, clientSessionTicket);
+            SetIfNotNull(_entityId, entityId);
+            SetIfNotNull(_entityType, entityType);
+            SetIfNotNull(_entityToken, entityToken);
+        }
     
         bool PlayFabAuthenticationContext::IsClientLoggedIn()
         {

--- a/source/code/source/playfab/PlayFabAuthenticationContext.cpp.ejs
+++ b/source/code/source/playfab/PlayFabAuthenticationContext.cpp.ejs
@@ -45,21 +45,6 @@
             SetIfNotNull(_entityType, entityType);
             SetIfNotNull(_entityToken, entityToken);
         }
-
-        void PlayFabAuthenticationContext::HandlePlayFabGameServerLogin(
-            const std::string& _playFabId,
-            const std::string& _clientSessionTicket,
-            const std::string& _entityId,
-            const std::string& _entityType,
-            const std::string& _entityToken
-        )
-        {
-            SetIfNotNull(_playFabId, playFabId);
-            SetIfNotNull(_clientSessionTicket, clientSessionTicket);
-            SetIfNotNull(_entityId, entityId);
-            SetIfNotNull(_entityType, entityType);
-            SetIfNotNull(_entityToken, entityToken);
-        }
     
         bool PlayFabAuthenticationContext::IsClientLoggedIn()
         {


### PR DESCRIPTION
This PR goes over the changes to cache the result of AuthenticateGameServerWithCustomId in a seperate "game server entity token".

Request actions for this specific function should be reviewed, not sure if they should have the same options as GetEntityToken but changes are as if they are. Might want to change the default EntityToken for the new "GameServerEntityToken" when setting request actions.

Deleting sets the HandleLogin to empty strings.
